### PR TITLE
fix(project update): Update project that is in edit mode

### DIFF
--- a/application/ui/src/features/projects-management/projects-list.component.tsx
+++ b/application/ui/src/features/projects-management/projects-list.component.tsx
@@ -47,7 +47,7 @@ export const ProjectsList = ({ projects, setProjectInEdition, projectIdInEdition
             return;
         }
 
-        updateProjectName(projectId, newName);
+        updateProjectName(id, newName);
     };
 
     const handleRename = (id: string) => {


### PR DESCRIPTION
The issue is that we used `projectId` instead of the `id` of project that is in edit state.