### PR TITLE
Set newest commit as a package version

### DIFF
--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -21,7 +21,7 @@
         "lint": "eslint ./src ./tests --max-warnings 0",
         "lint:fix": "eslint --fix ./src ./tests",
         "preview": "rsbuild preview",
-        "clone-geti-ui-packages": "npx degit git@github.com:open-edge-platform/geti.git/web_ui/packages/config packages/config --force && npx degit git@github.com:open-edge-platform/geti.git/web_ui/packages/ui#a85be8f4d393d78d1bafb82f14573aaa05cf2e46 packages/ui --force",
+        "clone-geti-ui-packages": "npx degit git@github.com:open-edge-platform/geti.git/web_ui/packages/config#e84dbb794fc7ce836ee4b58674baec8e5db8c5fd packages/config --force && npx degit git@github.com:open-edge-platform/geti.git/web_ui/packages/ui#e84dbb794fc7ce836ee4b58674baec8e5db8c5fd packages/ui --force",
         "preinstall": "npm run clone-geti-ui-packages",
         "type-check": "tsc --noEmit",
         "test:unit": "vitest",


### PR DESCRIPTION
We agreed to use latest commit hash to keep handle changes and updates in packages manually and adjust each application in suitable time if needed.

Additionally it will avoid errors in builds because package.json will be changed and docker will update dependencies.