### PR TITLE
Projects listing update

### DIFF
--- a/application/backend/app/rest/endpoints/projects.py
+++ b/application/backend/app/rest/endpoints/projects.py
@@ -150,6 +150,8 @@ def get_active_project(
 def get_projects_list(
     db_session: SessionDep,
     config_dispatcher: ConfigChangeDispatcherDep,
+    offset: Annotated[int, Query(ge=0, le=1000)] = 0,
+    limit: Annotated[int, Query(ge=0, le=1000)] = 20,
 ) -> ProjectsListSchema:
     """
     Retrieve a list of all available project configurations.
@@ -157,7 +159,7 @@ def get_projects_list(
     logger.debug("Received GET projects request.")
     service = ProjectService(session=db_session, config_change_dispatcher=config_dispatcher)
     try:
-        return service.list_projects()
+        return service.list_projects(offset=offset, limit=limit)
     except Exception as e:
         logger.exception(f"Internal error listing projects: {e}")
         raise HTTPException(

--- a/application/backend/app/services/project.py
+++ b/application/backend/app/services/project.py
@@ -115,13 +115,20 @@ class ProjectService:
             )
         return project_db_to_schema(project)
 
-    def list_projects(self) -> ProjectsListSchema:
+    def list_projects(self, offset: int = 0, limit: int = 20) -> ProjectsListSchema:
         """
-        List all projects.
+        List projects with pagination.
+
+        Parameters:
+            offset: Starting index (0-based)
+            limit: Maximum number of items to return
+
+        Returns:
+            ProjectsListSchema with paginated results and metadata
         """
-        logger.debug("Projects list requested")
-        items = projects_db_to_list_items(self.project_repository.get_all())
-        return ProjectsListSchema(projects=items)
+        logger.debug(f"Projects list requested with offset={offset}, limit={limit}")
+        projects, total = self.project_repository.get_paginated(offset=offset, limit=limit)
+        return projects_db_to_list_items(projects, total=total, offset=offset, limit=limit)
 
     def update_project(self, project_id: UUID, update_data: ProjectUpdateSchema) -> ProjectSchema:
         """

--- a/application/backend/app/services/schemas/base.py
+++ b/application/backend/app/services/schemas/base.py
@@ -16,3 +16,12 @@ class BaseIDSchema(BaseModel):
     """Base model with an id field."""
 
     id: UUID
+
+
+class Pagination(BaseModel):
+    """Pagination model."""
+
+    count: int  # number of items actually returned (might be less than limit if at the end)
+    total: int  # total number of items available
+    offset: int = 0  # index of the first item returned (0-based)
+    limit: int = 10  # number of items requested per page

--- a/application/backend/app/services/schemas/mappers/project.py
+++ b/application/backend/app/services/schemas/mappers/project.py
@@ -4,21 +4,42 @@
 from collections.abc import Iterable
 
 from db.models import ProjectDB
-from services.schemas.project import ProjectCreateSchema, ProjectSchema
+from services.schemas.base import Pagination
+from services.schemas.project import ProjectCreateSchema, ProjectSchema, ProjectsListSchema
 
 
 def project_db_to_schema(project: ProjectDB) -> ProjectSchema:
     """
     Map a ProjectDB ORM instance to a ProjectSchema.
     """
-    return ProjectSchema(id=project.id, name=project.name)
+    return ProjectSchema(id=project.id, name=project.name, active=project.active)
 
 
-def projects_db_to_list_items(projects: Iterable[ProjectDB]) -> list[ProjectSchema]:
+def projects_db_to_list_items(
+    projects: Iterable[ProjectDB], total: int, offset: int = 0, limit: int = 20
+) -> ProjectsListSchema:
     """
-    Bulk map an iterable of ProjectDB entities to list item schemas.
+    Map an iterable of ProjectDB entities to ProjectsListSchema with pagination metadata.
+
+    Parameters:
+        projects: Iterable of ProjectDB entities to map
+        total: Total number of projects available
+        offset: Starting index of the returned items
+        limit: Maximum number of items requested
+
+    Returns:
+        ProjectsListSchema with mapped projects and pagination metadata
     """
-    return [project_db_to_schema(p) for p in projects]
+    items = [project_db_to_schema(p) for p in projects]
+
+    pagination = Pagination(
+        count=len(items),
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
+
+    return ProjectsListSchema(projects=items, pagination=pagination)
 
 
 def project_schema_to_db(payload: ProjectCreateSchema) -> ProjectDB:

--- a/application/backend/app/services/schemas/project.py
+++ b/application/backend/app/services/schemas/project.py
@@ -4,7 +4,7 @@
 
 from pydantic import BaseModel, Field
 
-from services.schemas.base import BaseIDPayload, BaseIDSchema
+from services.schemas.base import BaseIDPayload, BaseIDSchema, Pagination
 
 
 class ProjectCreateSchema(BaseIDPayload):
@@ -18,7 +18,9 @@ class ProjectUpdateSchema(BaseModel):
 
 class ProjectSchema(BaseIDSchema):
     name: str
+    active: bool
 
 
 class ProjectsListSchema(BaseModel):
     projects: list[ProjectSchema]
+    pagination: Pagination


### PR DESCRIPTION
Closes #223 

This PR adds pagination support to the project listing endpoint and includes the active field in project schema responses. The changes enable clients to retrieve projects in pages and determine which project is currently active.

Key changes:

- Added pagination support to project listing with offset/limit parameters
- Included active boolean field in ProjectSchema responses
- Created new Pagination schema to standardize pagination metadata