### PR TITLE
Add smart-tools package to list of cloned packages

### DIFF
--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -31,7 +31,7 @@
                 "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
                 "@msw/playwright": "^0.4.2",
                 "@mswjs/source": "^0.5.0",
-                "@playwright/test": "^1.55.0",
+                "@playwright/test": "1.55.0",
                 "@rsbuild/core": "^1.4.13",
                 "@rsbuild/plugin-babel": "^1.0.6",
                 "@rsbuild/plugin-react": "^1.3.4",
@@ -2532,13 +2532,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-            "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+            "version": "1.55.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+            "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.56.1"
+                "playwright": "1.55.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -12672,13 +12672,13 @@
             "license": "MIT"
         },
         "node_modules/playwright": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+            "version": "1.55.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+            "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.56.1"
+                "playwright-core": "1.55.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -12691,9 +12691,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+            "version": "1.55.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+            "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -50,7 +50,7 @@
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
         "@msw/playwright": "^0.4.2",
         "@mswjs/source": "^0.5.0",
-        "@playwright/test": "^1.55.0",
+        "@playwright/test": "1.55.0",
         "@rsbuild/core": "^1.4.13",
         "@rsbuild/plugin-babel": "^1.0.6",
         "@rsbuild/plugin-react": "^1.3.4",


### PR DESCRIPTION
* Fix lockfile
* Make npm versioning more flexible
* Add smart-tools package

We should move from caret to tilde on the long run. On Tune we already did this. (`^` -> `~`)