### PR TITLE
chore(ci): update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -121,10 +121,11 @@
       matchUpdateTypes: ["major", "minor", "patch"],
     },
 
-    // Disable non-security upgrades for npm, except lock file update
+    // Disable non-security and lock file upgrades for npm
+    // Lock is updated manually
     {
       enabled: false,
-      matchDatasources: ["npm"],
+      matchManagers: ["npm"],
     },
 
     // NPM version in package.json is updated manually


### PR DESCRIPTION
Cosmetic updates in Renovate config, including:
- setting `schedule` for some types of updates
- fixing issue with unnecessary upgrade of  `ghcr.io/astral-sh/uv` (see this [PR](https://github.com/open-edge-platform/geti-prompt/pull/329/files#diff-f1a1876f4710f7ff810140f5c7d1d76bc19c4b6001a7aac8de83d1e3cf250799L8)) that shall be upgraded manually
Was tested in fork, PR examples: https://github.com/AlexanderBarabanov/geti-prompt/pulls



