### PR TITLE
chore: apply `trivy` recommendations to Dockerfile

### DIFF
--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-
 # Copy library and create proper directory structure
 COPY --from=libs . /geti_prompt/library
 


### PR DESCRIPTION
This PR applies some trivy recommendation and slightly reduces the image size 2.3->2.2.