### PR TITLE
ci: simplify distrib workflow trigger logic

### DIFF
--- a/.github/components-path-filters.yml
+++ b/.github/components-path-filters.yml
@@ -12,4 +12,6 @@ ui:
   - .github/workflows/**
 
 distrib:
-  - application/docker/**
+  - application/**
+  - library/**
+  - .github/workflows/**

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,19 +73,10 @@ jobs:
 
   distrib:
     name: Distrib build
-    needs: [build-parameters, library, backend, ui]
+    needs: [build-parameters]
     permissions:
       contents: read
-    if: |
-      always() &&
-      !cancelled() &&
-      !contains(needs.*.result, 'failure') &&
-      (
-        contains(fromJson(needs.build-parameters.outputs.components-list), 'distrib') ||
-        contains(fromJson(needs.build-parameters.outputs.components-list), 'library') ||
-        contains(fromJson(needs.build-parameters.outputs.components-list), 'backend') ||
-        contains(fromJson(needs.build-parameters.outputs.components-list), 'ui')
-      )
+    if: needs.build-parameters.outputs.components-list && contains(fromJson(needs.build-parameters.outputs.components-list), 'distrib')
     uses: ./.github/workflows/distrib.yml
     with:
       build_version: ${{ needs.build-parameters.outputs.build_version }}


### PR DESCRIPTION
- Remove dependencies on library, backend, and ui jobs
- Trigger distrib only when distrib-specific files change
- Expand distrib path filters to include all application and library files