### PR TITLE
fix(labels): Label is properly edited when only color has been changed

### DIFF
--- a/application/ui/src/features/prompts/visual-prompt/labels-management/edit-label/edit-label.component.tsx
+++ b/application/ui/src/features/prompts/visual-prompt/labels-management/edit-label/edit-label.component.tsx
@@ -35,7 +35,8 @@ export const EditLabel = ({ label, onAccept, onClose, isQuiet, width, isDisabled
 
     const validationError = validateLabelName(name, existingLabels, label.id);
     const hasSameName = name.trim() === label.name.trim();
-    const isEditDisabled = !!validationError || isDisabled || hasSameName;
+    const hasSameColor = color === label.color;
+    const isEditDisabled = !!validationError || isDisabled || (hasSameName && hasSameColor);
 
     const handleAccept = () => {
         if (isEditDisabled) return;
@@ -64,7 +65,6 @@ export const EditLabel = ({ label, onAccept, onClose, isQuiet, width, isDisabled
                 data-testid={'change-color-button'}
                 onColorChange={setColor}
                 size={'M'}
-                ariaLabelPrefix={'New label'}
             />
 
             <TextField


### PR DESCRIPTION
# Pull Request

## Description

<!-- What does this PR do? Why is it needed? -->

The issue is that save label button logic does not include color validation, i.e. when name is not changed button is disabled. That causes the issue when label's color change, user is not able to submit the change. This PR fixes that issue.

## Type of Change

- [ ] ✨ `feat` - New feature
- [X] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

Closes #502 

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
