### PR TITLE
fix: ensure cost_matrix is float32 in linear_sum_assignment for compatibility

### DIFF
--- a/library/src/getiprompt/components/linear_sum_assignment.py
+++ b/library/src/getiprompt/components/linear_sum_assignment.py
@@ -89,6 +89,9 @@ class LinearSumAssignment(nn.Module):
 
     def _scipy(self, cost_matrix: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Use scipy for optimal, fast solution (not exportable)."""
+        # torch.Tensor only supports float32 on CPU
+        if cost_matrix.dtype != torch.float32:
+            cost_matrix = cost_matrix.float()
         cost_np = cost_matrix.detach().cpu().numpy()
         row_ind, col_ind = scipy_linear_sum_assignment(cost_np, maximize=self.maximize)
         return (


### PR DESCRIPTION
# Pull Request

## Description

Ensure cost_matrix is float32 in linear_sum_assignment for compatibility

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
