### PR TITLE
chore: Set cursor pointer for buttons

### DIFF
--- a/application/ui/src/index.scss
+++ b/application/ui/src/index.scss
@@ -63,3 +63,7 @@ svg {
     }
     z-index: 100000 !important;
 }
+
+button[class*='spectrum-BaseButton'] {
+    cursor: pointer;
+}


### PR DESCRIPTION
# Pull Request

## Description

<!-- What does this PR do? Why is it needed? -->

By default spectrum sets `cursor: default` for buttons. This PR changes it.

## Type of Change

- [ ] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [X] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
