### PR TITLE
Enable empty templates while agreeing on the content of templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Question or Discussion
     url: https://github.com/open-edge-platform/geti-prompt/discussions


### PR DESCRIPTION
# Pull Request

## Description

Enable empty issue templates to allow free-form issues. This lets the team review and agree on template content, deciding which fields should be mandatory before reintroducing structured templates.

## Type of Change

- [X] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance
