### PR TITLE
refactor(sam): Move decoding from `useEffect` to `onPointerMove` handler

### DIFF
--- a/application/ui/src/features/annotator/providers/annotation-actions-provider.component.tsx
+++ b/application/ui/src/features/annotator/providers/annotation-actions-provider.component.tsx
@@ -30,6 +30,7 @@ type AnnotationActionsProviderProps = {
     initialAnnotationsDTO?: AnnotationType[];
     labels?: LabelType[];
 };
+
 export const AnnotationActionsProvider = ({
     children,
     initialAnnotationsDTO,
@@ -56,14 +57,13 @@ export const AnnotationActionsProvider = ({
     };
 
     const addAnnotations = (shapes: Shape[], annotationLabels: LabelType[]) => {
-        setAnnotations((prevAnnotations) => [
-            ...prevAnnotations,
-            ...shapes.map((shape) => ({
-                shape,
-                id: uuid(),
-                labels: annotationLabels,
-            })),
-        ]);
+        const newAnnotations: Annotation[] = shapes.map((shape) => ({
+            shape,
+            labels: annotationLabels,
+            id: uuid(),
+        }));
+
+        setAnnotations((prevAnnotations) => [...prevAnnotations, ...newAnnotations]);
     };
 
     const deleteAnnotations = (annotationIds: string[]) => {


### PR DESCRIPTION
# Pull Request

## Description

<!-- What does this PR do? Why is it needed? -->

We want to run decoding calculation only when pointer moves, it means we can use `onPointerMove` instead of updating `mousePosition` and triggering calculation using `useEffect`.
Also updated `deleteAnnotationsByLabelId` to make it work when there are more labels (edge case that might be useful for later, not a big change).

## Type of Change

- [ ] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [X] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
