### PR TITLE
fix: correct image dimension extraction in visual prompt processing

### DIFF
--- a/application/backend/app/domain/services/schemas/mappers/prompt.py
+++ b/application/backend/app/domain/services/schemas/mappers/prompt.py
@@ -185,7 +185,7 @@ def visual_prompt_to_sample(
 
     # Convert frame: HWC numpy → CHW tensor
     frame_chw = tv_tensors.Image(from_numpy(frame).permute(2, 0, 1))
-    height, width = frame_chw.shape[:2]
+    height, width = frame_chw.shape[-2:]
 
     # Group annotations by label_id
     label_groups: dict[UUID, list[Any]] = {}

--- a/library/src/getiprompt/components/feature_extractors/masked_feature_extractor.py
+++ b/library/src/getiprompt/components/feature_extractors/masked_feature_extractor.py
@@ -83,7 +83,6 @@ class MaskedFeatureExtractor(nn.Module):
             strict=True,
         ):
             for category_id, mask in zip(category_ids_tensor, masks_tensor, strict=True):
-                category_id = category_id.item()
                 pooled_mask = self.transform(mask).to(embedding.device)
                 flatten_ref_masks[category_id].append(pooled_mask)
                 keep = pooled_mask.flatten().bool()


### PR DESCRIPTION
# Pull Request

## Description

Fix incorrect image dimension extraction when converting visual prompts to training samples. The code was using `shape[:2]` on a CHW tensor, which returned `(C, H)` instead of `(H, W)`. This caused masks to be created with wrong dimensions (e.g., `[1, 3, 3840]` instead of `[1, H, W]`).

Also removes an unnecessary `.item()` call in the masked feature extractor that was converting tensor category IDs to Python scalars.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 docs - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

None

---

## Examples

**Before:**
```python
frame_chw = tv_tensors.Image(from_numpy(frame).permute(2, 0, 1))  # Shape: (C, H, W)
height, width = frame_chw.shape[:2]  # Wrong: returns (C, H) = (3, 1280)
```

**After:**
```python
frame_chw = tv_tensors.Image(from_numpy(frame).permute(2, 0, 1))  # Shape: (C, H, W)
height, width = frame_chw.shape[-2:]  # Correct: returns (H, W) = (1280, 720)
