### PR TITLE
Add ZAP API and Schemathesis tests for xpu image

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -256,14 +256,16 @@ jobs:
           schema: 'http://localhost:9100/api/openapi.json'
           args: >-
             --continue-on-failure
+            --report-dir schemathesis-report
             --report junit
+            --report-junit-path schemathesis-report/junit.xml
 
       - name: Upload Schemathesis report
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: schemathesis-report-${{ matrix.ai-device }}
-          path: junit.xml
+          path: schemathesis-report/junit.xml
 
       - name: Re-check container health after testing
         if: always()


### PR DESCRIPTION
# Pull Request

## Description

This PR adds ZAP API and Schemathesis security scans done toward running xpu image.
Scans are to be done as part of security-scan.yml workflow.

## Type of Change

- [x ] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance
