### PR TITLE
fix: Prompt sidebar

### DIFF
--- a/application/ui/src/components/sidebar/sidebar.module.scss
+++ b/application/ui/src/components/sidebar/sidebar.module.scss
@@ -4,6 +4,7 @@
     border-top-width: var(--spectrum-alias-border-size-thin);
     border-top-style: solid;
     border-color: var(--spectrum-global-color-gray-50);
+    overflow-y: auto;
 }
 
 .toggleButton {

--- a/application/ui/src/features/prompts/visual-prompt/prompt-thumbnails/prompt-thumbnail-list/prompt-thumbnail-list.component.tsx
+++ b/application/ui/src/features/prompts/visual-prompt/prompt-thumbnails/prompt-thumbnail-list/prompt-thumbnail-list.component.tsx
@@ -22,7 +22,7 @@ export const PromptThumbnailList = () => {
     }
 
     return (
-        <Grid columns={repeat('auto-fill', minmax('size-2400', '1fr'))} gap={'size-100'}>
+        <Grid columns={repeat('auto-fill', minmax('size-2400', '1fr'))} autoRows={'size-2400'} gap={'size-100'}>
             {visualPrompts.map((prompt) => (
                 <PromptThumbnail key={prompt.id} prompt={prompt} />
             ))}

--- a/application/ui/src/features/prompts/visual-prompt/prompt-thumbnails/prompt-thumbnail/prompt-thumbnail.module.scss
+++ b/application/ui/src/features/prompts/visual-prompt/prompt-thumbnails/prompt-thumbnail/prompt-thumbnail.module.scss
@@ -13,6 +13,7 @@
     height: 100%;
     width: 100%;
     transition: transform 0.2s ease-in-out;
+    object-fit: cover;
 
     &:hover {
         transform: scale(1.1);


### PR DESCRIPTION
# Pull Request

## Description

<!-- What does this PR do? Why is it needed? -->

The issue was that there was no scrollbar in the sidebar when prompts didn't fit. Moreover when image was bigger than others, prompt list row could grow to its height which caused weird layout issues.
This PR fixes that.

## Type of Change

- [ ] ✨ `feat` - New feature
- [X] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->

<img width="2002" height="1293" alt="image" src="https://github.com/user-attachments/assets/8616c477-3cc9-47e7-82bd-d6599d4ad7a5" />

