### PR TITLE
Product rename: Geti Prompt -> Geti Instant Learn [Leftovers]

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -57,7 +57,7 @@ dev:
 
     wait
 
-# build geti prompt with optional port mapping
+# build Geti Instant Learn with optional port mapping
 build-image: (download-dataset source-dataset-dir)
     @echo "Building docker image for component: {{ component-name }}"
     @docker build \
@@ -76,7 +76,7 @@ build-image: (download-dataset source-dataset-dir)
 # To persist logs, add this to `docker run` args:
 # `--volume "{{ component-name }}-logs":/instant_learn/logs \`
 # Add either line, or both.
-# launch geti prompt with optional webcam, volume and port mapping
+# launch Geti Instant Learn with optional webcam, volume and port mapping
 run-image: build-image
     #!/usr/bin/env bash
     set -euo pipefail
@@ -136,7 +136,7 @@ show-size:
     # https://github.com/casey/just?tab=readme-ov-file#escaping-
     @docker image inspect "{{ image-name }}" --format='{{{{.Size}}' | numfmt --to=iec
 
-# test geti prompt docker image using bash script
+# test Geti Instant Learn docker image using bash script
 test-image:
     #!/usr/bin/env bash
     echo "Testing docker image for component: {{ component-name }} with build-target: {{ build-target }}"

--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@geti/prompt",
+    "name": "@geti/instantlearn",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@geti/prompt",
+            "name": "@geti/instantlearn",
             "version": "1.0.0",
             "hasInstallScript": true,
             "workspaces": [

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@geti/prompt",
+    "name": "@geti/instantlearn",
     "version": "1.0.0",
     "private": true,
     "type": "module",

--- a/application/ui/src-tauri/msix/AppxManifest.xml
+++ b/application/ui/src-tauri/msix/AppxManifest.xml
@@ -4,7 +4,7 @@
          xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
 
-    <Identity Name="intel.geti.prompt" Publisher="CN=Intel Corporation, O=Intel Corporation, S=California, C=US" Version="1.0.0.0"/>
+    <Identity Name="intel.instant.learn" Publisher="CN=Intel Corporation, O=Intel Corporation, S=California, C=US" Version="1.0.0.0"/>
 
     <Properties>
         <DisplayName>Intel Geti Instant Learn</DisplayName>

--- a/rename.sh
+++ b/rename.sh
@@ -8,6 +8,9 @@ echo ""
 
 PATTERNS=(
     "Geti Prompt:Geti Instant Learn"
+    "geti prompt:Geti Instant Learn"
+    "geti/prompt:geti/instantlearn"
+    "geti.prompt:instant.learn"
     "GetiPrompt:InstantLearn"
     "GETI_PROMPT:INSTANT_LEARN"
     "GETIPROMPT:INSTANTLEARN"


### PR DESCRIPTION
## Description

Renaming the codebase and repository to **Geti Instant learn**.

## Migration Plan

**Timeline**: 03/02/2026 12-14 CET


### Renaming Scope 

**Documentation (README, docs, licenses, etc):**

```
Geti Prompt → Geti Instant Learn
```

**Code occurrences and file/directory names:**

```
"Geti Prompt:Geti Instant Learn"
"geti prompt:Geti Instant Learn"
"geti/prompt:geti/instantlearn"
"geti.prompt:instant.learn"
"GetiPrompt:InstantLearn"
"GETI_PROMPT:INSTANT_LEARN"
"GETIPROMPT:INSTANTLEARN"
"geti-prompt:instant-learn"
"geti_prompt:instant_learn"
"getiprompt:instantlearn"

**Repository:**
```
geti-prompt → instant-learn
```

### Migration steps

1. Freeze merges to main for ~2 hours  03/02/2026 12-14 CET.
2. Execute the renaming script in this PR and merge to main.
3. Rename repo: `geti-prompt` ->  `instant-learn`
4. Unfreeze.  Apply `rename.sh` to existing feature branches after this PR is merged to avoid merge conflicts:

```bash
git fetch origin
git checkout <your-feature-branch>
git checkout origin/main -- rename.sh
./rename.sh
git commit -am "chore: rename getiprompt to instantlearn"
git merge origin/main

# The merge will reuslt in conflicts in uv.lock files in the library and the app. 
# please delete and regenerate both of them 

git add -A
git push origin <your-feature-branch>
```
Please comment if there are questions/concerns 