### PR TITLE
fix: Pass camera name while camera edition

### DIFF
--- a/application/ui/src/features/sources-sinks/sources/usb-camera/edit-usb-camera-source.component.tsx
+++ b/application/ui/src/features/sources-sinks/sources/usb-camera/edit-usb-camera-source.component.tsx
@@ -28,6 +28,8 @@ const EditUsbCameraSourceContent = ({ source, onSaved, availableUsbCameras }: Ed
     const isButtonDisabled = selectedDeviceId == source.config.device_id || updateUsbCameraSource.isPending;
 
     const handleUpdateUsbCameraSource = (active: boolean) => {
+        const name = availableUsbCameras.find((camera) => camera.device_id === selectedDeviceId)?.name;
+
         updateUsbCameraSource.mutate(
             source.id,
             {
@@ -35,7 +37,7 @@ const EditUsbCameraSourceContent = ({ source, onSaved, availableUsbCameras }: Ed
                     source_type: 'usb_camera',
                     device_id: selectedDeviceId,
                     seekable: false,
-                    name: source.config.name,
+                    name,
                 },
                 active,
             },


### PR DESCRIPTION
# Pull Request

## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes the issue that when user is editing a usb camera, `name` property is not sent, therefore `null` is displayed as camera name.

## Type of Change

- [ ] ✨ `feat` - New feature
- [X] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
