### PR TITLE
close reader when main loop finished

### DIFF
--- a/application/backend/app/runtime/core/components/source.py
+++ b/application/backend/app/runtime/core/components/source.py
@@ -71,6 +71,8 @@ class Source(PipelineComponent):
                 logger.exception(f"Error reading from stream: {e}.")
                 time.sleep(0.1)
         logger.debug(f"Stopping the source {self._reader.__class__.__name__} loop")
+        # TODO: To investigate why reader.close() is fixing issue when switching cameras
+        self._reader.close()
 
     def _stop(self) -> None:
         """Clean up resources when component is stopped."""

--- a/application/backend/tests/unit/runtime/core/components/test_source.py
+++ b/application/backend/tests/unit/runtime/core/components/test_source.py
@@ -39,7 +39,7 @@ class TestSource:
         self.source.run()
 
         self.mock_stream_reader.connect.assert_called_once()
-        self.mock_stream_reader.close.assert_called_once()
+        assert self.mock_stream_reader.close.call_count == 2
 
         broadcast_calls = [call.args[0] for call in self.mock_broadcaster.broadcast.call_args_list]
         assert broadcast_calls == expected_broadcasts


### PR DESCRIPTION
# Pull Request

## Description

Add explicit call to stop reader so camera device is properly released.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

Relates to: https://github.com/open-edge-platform/instant-learn/issues/688

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
