### PR TITLE
feat: Add support for SAM3 model including configuration and integration in the pipeline

### DIFF
--- a/application/backend/app/domain/services/label.py
+++ b/application/backend/app/domain/services/label.py
@@ -232,9 +232,20 @@ class LabelService(BaseService):
         label_to_category_id = {label_id: idx for idx, label_id in enumerate(sorted_label_ids)}
         category_id_to_label_id = {idx: str(label_id) for label_id, idx in label_to_category_id.items()}
 
+        # Resolve label names from DB for text-based model prompting (e.g. SAM3)
+        label_id_to_name: dict[UUID, str] = {}
+        for label_id in sorted_label_ids:
+            label = self.label_repository.get_by_id(label_id)
+            if label is not None:
+                label_id_to_name[label_id] = label.name
+            else:
+                logger.warning("Label not found in DB: %s, falling back to UUID string", label_id)
+                label_id_to_name[label_id] = str(label_id)
+
         return CategoryMappings(
             label_to_category_id=label_to_category_id,
             category_id_to_label_id=category_id_to_label_id,
+            label_id_to_name=label_id_to_name,
         )
 
     def _handle_label_integrity_error(

--- a/application/backend/app/domain/services/schemas/label.py
+++ b/application/backend/app/domain/services/schemas/label.py
@@ -57,6 +57,7 @@ class CategoryMappings:
 
     label_to_category_id: dict[UUID, int]
     category_id_to_label_id: dict[int, str]
+    label_id_to_name: dict[UUID, str]
 
 
 @dataclass(frozen=True)

--- a/application/backend/app/domain/services/schemas/mappers/prompt.py
+++ b/application/backend/app/domain/services/schemas/mappers/prompt.py
@@ -148,6 +148,7 @@ def visual_prompt_to_sample(
     frame: np.ndarray,
     label_to_category_id: dict[UUID, int],
     label_shot_counts: dict[UUID, int],
+    label_id_to_name: dict[UUID, str] | None = None,
 ) -> Sample:
     """
     Convert a visual prompt to a Sample with merged semantic masks.
@@ -160,6 +161,8 @@ def visual_prompt_to_sample(
         frame: RGB image as numpy array (H, W, C)
         label_to_category_id: Mapping from label UUID to category ID (shared across batch)
         label_shot_counts: Current shot count per label (modified in-place)
+        label_id_to_name: Mapping from label UUID to human-readable name.
+            Used as text prompts by models like SAM3. Falls back to UUID string if not provided.
 
     Returns:
         Sample with merged masks, one per unique label in the prompt
@@ -209,7 +212,7 @@ def visual_prompt_to_sample(
         semantic_mask = np.any(instance_masks, axis=0).astype(np.uint8)  # (H, W) boolean
 
         category_id = label_to_category_id[label_id]
-        category_name = str(label_id)
+        category_name = label_id_to_name.get(label_id, str(label_id)) if label_id_to_name else str(label_id)
 
         # Get the current shot number for this label (from previous prompts)
         current_shot = label_shot_counts.get(label_id, 0)

--- a/application/backend/app/domain/services/schemas/processor.py
+++ b/application/backend/app/domain/services/schemas/processor.py
@@ -18,6 +18,7 @@ class ModelType(StrEnum):
     MATCHER = "matcher"
     PERDINO = "perdino"
     SOFT_MATCHER = "soft_matcher"
+    SAM3 = "sam3"
 
 
 ALLOWED_SAM_MODELS: tuple[SAMModelName, ...] = (
@@ -137,7 +138,29 @@ class SoftMatcherConfig(BaseModelConfig):
     }
 
 
-ModelConfig = Annotated[PerDinoConfig | MatcherConfig | SoftMatcherConfig, Field(discriminator="model_type")]
+class Sam3Config(BaseModel):
+    """Configuration for SAM3 text-prompted segmentation model."""
+
+    model_type: Literal[ModelType.SAM3] = ModelType.SAM3
+    confidence_threshold: float = Field(default=0.5, gt=0.0, lt=1.0)
+    resolution: int = Field(default=1008, gt=0)
+    precision: str = Field(default="fp32", description="Model precision ('bf16' or 'fp32')")
+    compile_models: bool = Field(default=False)
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "model_type": "sam3",
+                "confidence_threshold": 0.5,
+                "resolution": 1008,
+                "precision": "fp32",
+                "compile_models": False,
+            }
+        }
+    }
+
+
+ModelConfig = Annotated[PerDinoConfig | MatcherConfig | SoftMatcherConfig | Sam3Config, Field(discriminator="model_type")]
 
 
 @dataclass(kw_only=True)

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -4,9 +4,10 @@
 from instantlearn.data.base.batch import Batch
 from instantlearn.models.matcher import Matcher
 from instantlearn.models.per_dino import PerDino
+from instantlearn.models.sam3 import SAM3
 from instantlearn.models.soft_matcher import SoftMatcher
 
-from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, SoftMatcherConfig
+from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from runtime.core.components.base import ModelHandler
 from runtime.core.components.models.inference_model import InferenceModelHandler
 from runtime.core.components.models.passthrough_model import PassThroughModelHandler
@@ -64,6 +65,15 @@ class ModelFactory:
                     softmatching_score_threshold=config.softmatching_score_threshold,
                     softmatching_bidirectional=config.softmatching_bidirectional,
                     use_nms=config.use_nms,
+                    precision=config.precision,
+                    compile_models=config.compile_models,
+                    device=settings.device,
+                )
+                return InferenceModelHandler(model, reference_batch)
+            case Sam3Config() as config:
+                model = SAM3(
+                    confidence_threshold=config.confidence_threshold,
+                    resolution=config.resolution,
                     precision=config.precision,
                     compile_models=config.compile_models,
                     device=settings.device,

--- a/application/backend/app/runtime/pipeline_manager.py
+++ b/application/backend/app/runtime/pipeline_manager.py
@@ -377,7 +377,11 @@ class PipelineManager:
 
                     frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                     sample = visual_prompt_to_sample(
-                        prompt, frame_rgb, category_mappings.label_to_category_id, label_shot_counts
+                        prompt,
+                        frame_rgb,
+                        category_mappings.label_to_category_id,
+                        label_shot_counts,
+                        label_id_to_name=category_mappings.label_id_to_name,
                     )
                     samples.append(sample)
 

--- a/application/backend/tests/unit/domain/services/schemas/mappers/test_prompt_mapper.py
+++ b/application/backend/tests/unit/domain/services/schemas/mappers/test_prompt_mapper.py
@@ -54,19 +54,21 @@ class TestPromptMapper:
 
         label_to_category_id = {label_id: 0}
         label_shot_counts: dict[uuid.UUID, int] = {}
+        label_id_to_name = {label_id: "test_object"}
 
         result = visual_prompt_to_sample(
             prompt_db,
             frame=sample_frame,
             label_to_category_id=label_to_category_id,
             label_shot_counts=label_shot_counts,
+            label_id_to_name=label_id_to_name,
         )
 
         assert result is not None
         assert isinstance(result, Sample)
         assert np.array_equal(result.image.permute(1, 2, 0).numpy(), sample_frame)
         assert len(result.categories) == 1
-        assert result.categories[0] == str(label_id)
+        assert result.categories[0] == "test_object"
         assert label_shot_counts[label_id] == 1
 
     def test_visual_prompt_to_sample_raises_error_without_polygons(self, sample_frame: np.ndarray) -> None:
@@ -141,19 +143,21 @@ class TestPromptMapper:
 
         label_to_category_id = {label_id_1: 0, label_id_2: 1}
         label_shot_counts: dict[uuid.UUID, int] = {}
+        label_id_to_name = {label_id_1: "car", label_id_2: "person"}
 
         result = visual_prompt_to_sample(
             prompt_db,
             frame=sample_frame,
             label_to_category_id=label_to_category_id,
             label_shot_counts=label_shot_counts,
+            label_id_to_name=label_id_to_name,
         )
 
         assert result is not None
         assert isinstance(result, Sample)
         assert len(result.categories) == 2
-        assert str(label_id_1) in result.categories
-        assert str(label_id_2) in result.categories
+        assert "car" in result.categories
+        assert "person" in result.categories
         assert label_shot_counts[label_id_1] == 1
         assert label_shot_counts[label_id_2] == 1
 

--- a/application/backend/tests/unit/domain/services/test_label.py
+++ b/application/backend/tests/unit/domain/services/test_label.py
@@ -228,9 +228,13 @@ def test_get_visualization_labels_returns_rgb_mapping(label_service, mock_label_
     mock_label_repository.list_all_by_project.assert_called_once_with(project_id)
 
 
-def test_build_category_mappings_sorted_by_label_id_string(label_service) -> None:
+def test_build_category_mappings_sorted_by_label_id_string(label_service, mock_label_repository) -> None:
     label_id_a = UUID("00000000-0000-0000-0000-00000000000a")
     label_id_b = UUID("00000000-0000-0000-0000-00000000000b")
+
+    label_a = LabelDB(id=label_id_a, project_id=PROJECT_ID, name="apple", color="#ff0000")
+    label_b = LabelDB(id=label_id_b, project_id=PROJECT_ID, name="banana", color="#00ff00")
+    mock_label_repository.get_by_id.side_effect = lambda lid: {label_id_a: label_a, label_id_b: label_b}[lid]
 
     mappings = label_service.build_category_mappings([label_id_b, label_id_a])
 
@@ -242,4 +246,8 @@ def test_build_category_mappings_sorted_by_label_id_string(label_service) -> Non
     assert mappings.label_to_category_id == {
         label_id_a: 0,
         label_id_b: 1,
+    }
+    assert mappings.label_id_to_name == {
+        label_id_a: "apple",
+        label_id_b: "banana",
     }

--- a/application/backend/tests/unit/runtime/test_pipeline_manager.py
+++ b/application/backend/tests/unit/runtime/test_pipeline_manager.py
@@ -364,6 +364,7 @@ class TestPipelineManager:
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
                 label_to_category_id={label_id: 0},
                 category_id_to_label_id={0: str(label_id)},
+                label_id_to_name={label_id: "test_label"},
             )
 
             result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
@@ -407,6 +408,7 @@ class TestPipelineManager:
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
                 label_to_category_id={label_id_a: 0, label_id_b: 1},
                 category_id_to_label_id={0: str(label_id_a), 1: str(label_id_b)},
+                label_id_to_name={label_id_a: "label_a", label_id_b: "label_b"},
             )
 
             result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
@@ -443,7 +445,7 @@ class TestPipelineManager:
         ):
             prompt_repo_cls.return_value.list_all_by_project.return_value = [visual_prompt]
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
-                label_to_category_id={}, category_id_to_label_id={}
+                label_to_category_id={}, category_id_to_label_id={}, label_id_to_name={}
             )
 
             result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
@@ -470,7 +472,7 @@ class TestPipelineManager:
         ):
             prompt_repo_cls.return_value.list_all_by_project.return_value = [visual_prompt]
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
-                label_to_category_id={}, category_id_to_label_id={}
+                label_to_category_id={}, category_id_to_label_id={}, label_id_to_name={}
             )
 
             result = mgr.get_reference_batch(project_id, PromptType.VISUAL)

--- a/application/ui/src/api/index.ts
+++ b/application/ui/src/api/index.ts
@@ -32,11 +32,13 @@ export type MQTTSinkType = SinkWithoutConfig & { config: MQTTConfig };
 type MatcherConfig = components['schemas']['MatcherConfig'];
 type PerDINOConfig = components['schemas']['PerDinoConfig'];
 type SoftMatcherConfig = components['schemas']['SoftMatcherConfig'];
+type Sam3Config = components['schemas']['Sam3Config'];
 
 export type ModelType = components['schemas']['ProcessorSchema'];
 export type MatcherModel = Omit<ModelType, 'config'> & { config: MatcherConfig };
 export type PerDINOModel = Omit<ModelType, 'config'> & { config: PerDINOConfig };
 export type SoftMatcherModel = Omit<ModelType, 'config'> & { config: SoftMatcherConfig };
+export type Sam3Model = Omit<ModelType, 'config'> & { config: Sam3Config };
 
 export { $api, client } from './client';
 export {

--- a/application/ui/src/features/prompts/models/api/use-get-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-models.ts
@@ -5,7 +5,7 @@
 
 import { useEffect, useRef } from 'react';
 
-import { $api, MatcherModel, ModelListType, PerDINOModel, SoftMatcherModel } from '@/api';
+import { $api, MatcherModel, ModelListType, PerDINOModel, Sam3Model, SoftMatcherModel } from '@/api';
 import { useProjectIdentifier } from '@/hooks';
 import { v4 as uuid } from 'uuid';
 
@@ -89,6 +89,21 @@ const getDefaultSoftMatcherModel = (id: string): SoftMatcherModel => {
     };
 };
 
+const getDefaultSam3Model = (id: string): Sam3Model => {
+    return {
+        id,
+        config: {
+            model_type: 'sam3',
+            confidence_threshold: 0.5,
+            resolution: 1008,
+            precision: 'fp32',
+            compile_models: false,
+        },
+        active: false,
+        name: 'SAM3',
+    };
+};
+
 export const useGetModels = () => {
     const { models } = useGetModelsQuery();
     const createModel = useCreateModel();
@@ -102,6 +117,7 @@ export const useGetModels = () => {
             createModel(getDefaultPerDINOModel(uuid()));
             createModel(getDefaultSoftMatcherModel(uuid()));
             createModel(getDefaultMatcherModel(uuid()));
+            createModel(getDefaultSam3Model(uuid()));
         }
     }, [models.length, createModel]);
 

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
@@ -5,12 +5,12 @@
 
 import { FormEvent, useState } from 'react';
 
-import { MatcherModel, ModelType, PerDINOModel, SoftMatcherModel } from '@/api';
+import { MatcherModel, ModelType, PerDINOModel, Sam3Model, SoftMatcherModel } from '@/api';
 import { Button, ButtonGroup, Content, Dialog, Divider, Flex, Form, Heading, Item, Picker, Switch } from '@geti/ui';
 
 import { useUpdateModel } from '../../api/use-update-model';
 import { NumberField } from './number-field.component';
-import { isMatcherModel, isPerDINOModel, isSoftMatcherModel } from './utils';
+import { isMatcherModel, isPerDINOModel, isSam3Model, isSoftMatcherModel } from './utils';
 
 const ENCODER_MODELS = [
     { label: 'DINOv3 Small', value: 'dinov3_small' },
@@ -518,6 +518,93 @@ interface ModelConfigurationDialogProps {
     onClose: () => void;
 }
 
+interface Sam3ConfigurationProps {
+    model: Sam3Model;
+    onClose: () => void;
+}
+
+const SAM3_PRECISIONS: { label: string; value: 'fp32' | 'bf16' }[] = [
+    { label: 'FP32', value: 'fp32' },
+    { label: 'BF16', value: 'bf16' },
+];
+
+const Sam3Configuration = ({ model, onClose }: Sam3ConfigurationProps) => {
+    const [confidenceThreshold, setConfidenceThreshold] = useState<number>(model.config.confidence_threshold);
+    const [resolution, setResolution] = useState<number>(model.config.resolution);
+    const [precision, setPrecision] = useState<'fp32' | 'bf16'>(model.config.precision as 'fp32' | 'bf16');
+    const [compileModels, setCompileModels] = useState<boolean>(model.config.compile_models);
+
+    const updateModelMutation = useUpdateModel();
+
+    const isConfigureButtonDisabled =
+        confidenceThreshold === model.config.confidence_threshold &&
+        resolution === model.config.resolution &&
+        precision === model.config.precision &&
+        compileModels === model.config.compile_models;
+
+    const updateModel = (event: FormEvent) => {
+        event.preventDefault();
+
+        updateModelMutation.mutate(
+            {
+                active: model.active,
+                name: model.name,
+                id: model.id,
+                config: {
+                    model_type: model.config.model_type,
+                    confidence_threshold: confidenceThreshold,
+                    resolution,
+                    precision,
+                    compile_models: compileModels,
+                },
+            },
+            onClose
+        );
+    };
+
+    return (
+        <Form onSubmit={updateModel}>
+            <Flex direction={'column'} gap={'size-200'}>
+                <NumberField
+                    label={'Confidence threshold'}
+                    minValue={0}
+                    maxValue={1}
+                    step={0.01}
+                    onChange={setConfidenceThreshold}
+                    value={confidenceThreshold}
+                />
+                <NumberField
+                    label={'Resolution'}
+                    minValue={224}
+                    maxValue={2048}
+                    step={16}
+                    onChange={setResolution}
+                    value={resolution}
+                />
+                <Selection label={'Precision'} value={precision} onChange={setPrecision} items={SAM3_PRECISIONS} />
+                <Flex alignItems={'center'} width={'100%'} wrap={'wrap'}>
+                    <Switch isEmphasized isSelected={compileModels} onChange={setCompileModels}>
+                        Optimise models
+                    </Switch>
+                </Flex>
+                <ButtonGroup align={'end'}>
+                    <Button variant={'secondary'} onPress={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type={'submit'}
+                        variant={'primary'}
+                        isPending={updateModelMutation.isPending}
+                        isDisabled={isConfigureButtonDisabled}
+                    >
+                        Configure
+                    </Button>
+                </ButtonGroup>
+            </Flex>
+        </Form>
+    );
+};
+
 export const ModelConfigurationDialog = ({ model, onClose }: ModelConfigurationDialogProps) => {
     return (
         <Dialog width={'40vw'}>
@@ -530,6 +617,8 @@ export const ModelConfigurationDialog = ({ model, onClose }: ModelConfigurationD
                     <PerDINOConfiguration model={model} onClose={onClose} />
                 ) : isSoftMatcherModel(model) ? (
                     <SoftMatcherConfiguration model={model} onClose={onClose} />
+                ) : isSam3Model(model) ? (
+                    <Sam3Configuration model={model} onClose={onClose} />
                 ) : null}
             </Content>
         </Dialog>

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.ts
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MatcherModel, ModelType, PerDINOModel, SoftMatcherModel } from '@/api';
+import { MatcherModel, ModelType, PerDINOModel, Sam3Model, SoftMatcherModel } from '@/api';
 
 export const isMatcherModel = (m: ModelType): m is MatcherModel => m.config.model_type === 'matcher';
 export const isPerDINOModel = (m: ModelType): m is PerDINOModel => m.config.model_type === 'perdino';
 export const isSoftMatcherModel = (m: ModelType): m is SoftMatcherModel => m.config.model_type === 'soft_matcher';
+export const isSam3Model = (m: ModelType): m is Sam3Model => m.config.model_type === 'sam3';


### PR DESCRIPTION
# Pull Request

## Description

<img width="2488" height="1146" alt="Screenshot 2026-02-10 at 11 39 16" src="https://github.com/user-attachments/assets/d8d4c7b5-c853-4377-b216-cb0a9729966d" />


Add SAM3 (text-prompted segmentation) model support across the full stack. SAM3 uses CLIP text prompts derived from label names, unlike the existing vision-prompted models (Matcher, PerDINO, SoftMatcher) that rely on reference masks.

This PR includes two key changes:

1. **Label name resolution** — `CategoryMappings` now resolves label UUIDs to human-readable names from the database, so models like SAM3 receive meaningful text prompts (e.g. "elephant") instead of UUID strings.

2. **SAM3 model integration** — Full backend + frontend wiring for SAM3 as a selectable model with its own configuration (confidence threshold, resolution, precision, compile toggle).

## Type of Change

- [x] ✨ `feat` - New feature

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

`CategoryMappings` dataclass now requires a `label_id_to_name` field. Any code constructing `CategoryMappings` directly must include it. All existing call sites and tests have been updated.

---

## Changes Made

### Backend

| File | Change |
|---|---|
| label.py | Added `label_id_to_name: dict[UUID, str]` to `CategoryMappings` |
| label.py | `build_category_mappings()` now queries DB for label names |
| prompt.py | `visual_prompt_to_sample()` uses label names for `Sample.categories` |
| processor.py | Added `SAM3` to `ModelType` enum, `Sam3Config` schema, updated `ModelConfig` union |
| model.py | Added `Sam3Config` case to `ModelFactory` |
| pipeline_manager.py | Passes `label_id_to_name` through to sample mapper |

### Frontend

| File | Change |
|---|---|
| index.ts | Added `Sam3Config` type and `Sam3Model` export |
| utils.ts | Added `isSam3Model()` type guard |
| model-configuration-dialog.component.tsx | Added `Sam3Configuration` form component |
| use-get-models.ts | Added `getDefaultSam3Model()` to auto-creation |

### Tests

| File | Change |
|---|---|
| test_label.py | Updated `build_category_mappings` test with label name assertions |
| test_prompt_mapper.py | Tests now pass `label_id_to_name` and assert real names |
| test_pipeline_manager.py | Mocks updated with `label_id_to_name` field |

## Examples

SAM3 config (backend):
```json
{
  "model_type": "sam3",
  "confidence_threshold": 0.5,
  "resolution": 1008,
  "precision": "fp32",
  "compile_models": false
}
```

After regenerating OpenAPI types (`PYTHONPATH=app python openapi.py ../ui/src/api && cd ../ui && npm run build:api:types`), SAM3 appears in the UI model picker dropdown with a simplified config dialog (no encoder/decoder selection needed).