### PR TITLE
chore(ci): enable lock file regeneration by Renovate for `cargo`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,10 +38,10 @@
   prHourlyLimit: 10,
 
   packageRules: [
-    // Disable non-security upgrades for pypi, crate and npm, except lock file update
+    // Disable non-security upgrades for pypi and crate, except lock file update
     {
       enabled: false,
-      matchDatasources: ["pypi", "crate", "npm"],
+      matchDatasources: ["pypi", "crate"],
     },
 
     // Disable python upgrades, except patch and digest pinning
@@ -120,6 +120,13 @@
       matchDatasources: ["docker"],
       matchPackageNames: ["ghcr.io/astral-sh/uv"],
       matchUpdateTypes: ["major", "minor", "patch"],
+    },
+
+    // Disable non-security and lock file upgrades for npm
+    // FIXME: lock update is disabled due to dependency conflict issue
+    {
+      enabled: false,
+      matchManagers: ["npm"],
     },
 
     // NPM version in package.json is updated manually


### PR DESCRIPTION
# Pull Request

This PR enable `cargo` support by Renovate (lock file regeneration to receive upgrades required by Dependabot).
NPM lock regeneration will be enabled in a separate PR,

## Type of Change

- [x] 🔧 `chore` - Maintenance

Was tested in a fork: https://github.com/AlexanderBarabanov/geti-instant-learn/issues/6

