### PR TITLE
fix(ci): prevent issue creation by `daily.yml` if similar issue already exists

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -59,7 +59,7 @@ jobs:
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['daily-failure', 'automated'],
+              labels: 'daily-failure,automated',
               state: 'open',
             });
 


### PR DESCRIPTION
# Pull Request

## Description

This PR updates `daily.yml` to prevent issue creation if similar issue already exists.

Was tests in fork:
1) Issue was not created due to existing one - https://github.com/AlexanderBarabanov/geti-instant-learn/actions/runs/23250415303
2) Issue created (no similar issue exists) - https://github.com/AlexanderBarabanov/geti-instant-learn/actions/runs/23250663505

## Type of Change

- [x] 🐞 `fix` - Bug fix