### PR TITLE
fix: merge same-category masks per image in MaskedFeatureExtractor

### DIFF
--- a/library/src/instantlearn/components/feature_extractors/masked_feature_extractor.py
+++ b/library/src/instantlearn/components/feature_extractors/masked_feature_extractor.py
@@ -83,9 +83,19 @@ class MaskedFeatureExtractor(nn.Module):
             category_ids,
             strict=True,
         ):
+            # Merge same-category masks within this image to avoid
+            # duplicating the image embedding (which breaks bidirectional
+            # matching in downstream prompt generators).
+            per_image_cat_masks: dict[int, torch.Tensor] = {}
             for category_id, mask in zip(category_ids_tensor, masks_tensor, strict=True):
                 cat_id = int(category_id.item()) if isinstance(category_id, torch.Tensor) else category_id
-                pooled_mask = self.transform(mask).to(embedding.device)
+                if cat_id in per_image_cat_masks:
+                    per_image_cat_masks[cat_id] = torch.maximum(per_image_cat_masks[cat_id], mask)
+                else:
+                    per_image_cat_masks[cat_id] = mask
+
+            for cat_id, merged_mask in per_image_cat_masks.items():
+                pooled_mask = self.transform(merged_mask).to(embedding.device)
                 masks_per_cat[cat_id].append(pooled_mask)
 
                 # Extract masked embeddings

--- a/library/tests/unit/components/feature_extractors/test_masked_feature_extractor.py
+++ b/library/tests/unit/components/feature_extractors/test_masked_feature_extractor.py
@@ -251,7 +251,12 @@ class TestMaskedFeatureExtractor:
         pytest.assume(ref_features.masked_ref_embeddings.shape == (1, 1, embedding_dim))
 
     def test_forward_same_class_id_multiple_masks(self) -> None:
-        """Test MaskedFeatureExtractor with multiple masks for the same class."""
+        """Test that same-category masks on one image are OR-merged.
+
+        When multiple instance masks share a category on a single image,
+        they should be merged into one semantic mask. The image embedding
+        is stored once (not duplicated per instance mask).
+        """
         extractor = MaskedFeatureExtractor(
             input_size=224,
             patch_size=14,
@@ -273,10 +278,44 @@ class TestMaskedFeatureExtractor:
 
         ref_features = extractor(embeddings, masks, category_ids)
 
-        # Both masks have same category, so aggregated
+        # Both masks have same category — merged into one
         pytest.assume(ref_features.category_ids == [1])
         pytest.assume(ref_features.masked_ref_embeddings.shape == (1, 1, embedding_dim))
-        # flatten_ref_masks should have 2x patches (one per mask)
+        # Embedding stored once (no duplication)
+        pytest.assume(ref_features.ref_embeddings.shape == (1, total_patches, embedding_dim))
+        pytest.assume(ref_features.flatten_ref_masks.shape == (1, total_patches))
+        # Merged mask covers both regions
+        pytest.assume(ref_features.flatten_ref_masks[0].sum() > 0)
+
+    def test_forward_same_category_not_merged_across_images(self) -> None:
+        """Test that same-category masks on different images are NOT merged.
+
+        Cross-image embeddings represent different visual features and must
+        be concatenated, not collapsed.
+        """
+        extractor = MaskedFeatureExtractor(
+            input_size=224,
+            patch_size=14,
+            device="cpu",
+        )
+
+        batch_size = 2
+        patches_per_dim = 16
+        total_patches = patches_per_dim * patches_per_dim
+        embedding_dim = 768
+        mask_height, mask_width = 224, 224
+
+        embeddings = torch.randn(batch_size, total_patches, embedding_dim)
+        masks = torch.zeros(batch_size, 1, mask_height, mask_width, dtype=torch.bool)
+        masks[0, 0, 50:100, 50:100] = True
+        masks[1, 0, 50:100, 50:100] = True
+        category_ids = torch.tensor([[1], [1]], dtype=torch.long)
+
+        ref_features = extractor(embeddings, masks, category_ids)
+
+        pytest.assume(ref_features.category_ids == [1])
+        # Two images → two embeddings concatenated (not merged)
+        pytest.assume(ref_features.ref_embeddings.shape == (1, total_patches * 2, embedding_dim))
         pytest.assume(ref_features.flatten_ref_masks.shape == (1, total_patches * 2))
 
     def test_forward_masked_embeddings_normalized(self) -> None:


### PR DESCRIPTION
When multiple instance masks share the same category on a single reference image, OR-merge them into one semantic mask before feature extraction. This prevents the image embedding from being duplicated per instance, which caused incorrect bidirectional matching in downstream prompt generators (BidirectionalPromptGenerator, SoftmatcherPromptGenerator).

This results in more detections. An example: 

No changes needed from application. 

<img width="1280" height="900" alt="Comp Large" src="https://github.com/user-attachments/assets/90b66168-b8d1-42d3-80c1-ba1d55b65d8c" />

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

Relates to #877 

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
