### PR TITLE
Limit the number of uv concurrent installs to avoid "No file descriptors available" error

### DIFF
--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN npm run build
 FROM python:3.13-slim@sha256:8bc60ca09afaa8ea0d6d1220bde073bacfedd66a4bf8129cbdc8ef0e16c8a952 AS runtime-base
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
+# If not limited, uv will use all cores (more than 100 for servers), resulting in No file descriptors available error
+ENV UV_CONCURRENT_INSTALLS=10
 # Disable Python downloads, because we want to use the system interpreter
 ENV UV_PYTHON_DOWNLOADS=0
 


### PR DESCRIPTION
When `just build-image` is called on z Xeon server (e.g. with 128 cores), uv creates up to <cores number> threads to handle the installation.
The result: 
154.2 error: Failed to bytecode-compile Python file in: .venv/lib/python3.13/site-packages
154.2   Caused by: Failed to start Python interpreter to run compile script
154.2   Caused by: No file descriptors available (os error 24)

This PR limits the number of concurrent thread to 10.