### PR TITLE
Rectangle annotations and SAM3 enablement

### DIFF
--- a/application/backend/app/api/endpoints/models.py
+++ b/application/backend/app/api/endpoints/models.py
@@ -36,7 +36,7 @@ def get_supported_models(
     offset: Annotated[int, Query(ge=0, le=1000)] = 0, limit: Annotated[int, Query(ge=0, le=1000)] = 20
 ) -> SupportedModelsListSchema:
     """Return all supported model types with default configs and accepted prompt types."""
-    all_models = SUPPORTED_MODELS_METADATA
+    all_models = list(SUPPORTED_MODELS_METADATA.values())
     paginated_models = all_models[offset : offset + limit]
     return SupportedModelsListSchema(
         models=paginated_models,

--- a/application/backend/app/domain/alembic/versions/2025_10_07_1055-80b4e8ca793f_create_db_tables.py
+++ b/application/backend/app/domain/alembic/versions/2025_10_07_1055-80b4e8ca793f_create_db_tables.py
@@ -31,7 +31,7 @@ def upgrade() -> None:
     sa.Column('name', sa.String(), nullable=False),
     sa.Column('active', sa.Boolean(), nullable=False),
     sa.Column('device', sa.String(), nullable=False, server_default='auto'),
-    sa.Column('prompt_mode', sa.String(), nullable=False, server_default='visual'),
+    sa.Column('prompt_mode', sa.String(), nullable=False, server_default='VISUAL'),
     sa.Column('id', sa.Uuid(), nullable=False),
     sa.Column("created_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
     sa.Column("updated_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),

--- a/application/backend/app/domain/db/models.py
+++ b/application/backend/app/domain/db/models.py
@@ -171,7 +171,7 @@ class ProjectDB(Base):
     name: Mapped[str] = mapped_column(nullable=False)
     active: Mapped[bool] = mapped_column(nullable=False, default=False)
     device: Mapped[str] = mapped_column(nullable=False, default="auto")
-    prompt_mode: Mapped[str] = mapped_column(nullable=False, default="visual")
+    prompt_mode: Mapped[str] = mapped_column(nullable=False, default="VISUAL")
     sources: Mapped[list[SourceDB]] = relationship(
         back_populates="project", cascade="all, delete-orphan", passive_deletes=True
     )

--- a/application/backend/app/domain/repositories/base.py
+++ b/application/backend/app/domain/repositories/base.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime
 from typing import TypeVar, cast
 from uuid import UUID
@@ -46,6 +46,14 @@ class BaseRepository[ModelType: Base]:
     def get_by_id(self, object_id: UUID) -> ModelType | None:
         """Retrieve an item by its ID."""
         return self.session.get(self.model, object_id)
+
+    def get_by_ids(self, object_ids: Iterable[UUID]) -> Sequence[ModelType]:
+        """Retrieve items by a collection of IDs in a single query."""
+        ids = list(object_ids)
+        if not ids:
+            return []
+        stmt = select(self.model).where(self.model.id.in_(ids))
+        return self.session.execute(stmt).scalars().all()
 
     def exists(self, object_id: UUID) -> bool:
         """Check if an item exists by its ID."""

--- a/application/backend/app/domain/repositories/prompt.py
+++ b/application/backend/app/domain/repositories/prompt.py
@@ -23,7 +23,7 @@ class PromptRepository(ProjectComponentRepository[PromptDB]):
         """Initialize the repository."""
         super().__init__(session=session, model=PromptDB)
 
-    def list_all_by_project(self, project_id: UUID, prompt_type: PromptType | None = None) -> Sequence[PromptDB]:
+    def list_by_project_and_type(self, project_id: UUID, prompt_type: PromptType | None = None) -> Sequence[PromptDB]:
         """
         Retrieve all prompts belonging to a project with optional filtering by prompt type.
         """

--- a/application/backend/app/domain/services/label.py
+++ b/application/backend/app/domain/services/label.py
@@ -237,12 +237,14 @@ class LabelService(BaseService):
         )
 
     def get_label_names(self, label_ids: Iterable[UUID]) -> dict[UUID, str]:
-        """Get label names for a set of label IDs."""
-        result: dict[UUID, str] = {}
-        for label_id in label_ids:
-            label = self.label_repository.get_by_id(label_id)
-            result[label_id] = label.name if label else str(label_id)
-        return result
+        """
+        Get label names for a set of label IDs.
+        Returns a mapping of label IDs to their names or their UUIDs if names were not found.
+        """
+        requested_ids = set(label_ids)
+        labels = self.label_repository.get_by_ids(requested_ids)
+        db_id_to_name = {label.id: label.name for label in labels}
+        return {label_id: db_id_to_name.get(label_id, str(label_id)) for label_id in requested_ids}
 
     def _handle_label_integrity_error(
         self,

--- a/application/backend/app/domain/services/label.py
+++ b/application/backend/app/domain/services/label.py
@@ -233,9 +233,16 @@ class LabelService(BaseService):
         category_id_to_label_id = {idx: str(label_id) for label_id, idx in label_to_category_id.items()}
 
         return CategoryMappings(
-            label_to_category_id=label_to_category_id,
-            category_id_to_label_id=category_id_to_label_id,
+            label_to_category_id=label_to_category_id, category_id_to_label_id=category_id_to_label_id
         )
+
+    def get_label_names(self, label_ids: Iterable[UUID]) -> dict[UUID, str]:
+        """Get label names for a set of label IDs."""
+        result: dict[UUID, str] = {}
+        for label_id in label_ids:
+            label = self.label_repository.get_by_id(label_id)
+            result[label_id] = label.name if label else str(label_id)
+        return result
 
     def _handle_label_integrity_error(
         self,

--- a/application/backend/app/domain/services/project.py
+++ b/application/backend/app/domain/services/project.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from api.error_handler import extract_constraint_name
 from domain.db.constraints import UniqueConstraintName
-from domain.db.models import ProjectDB
+from domain.db.models import ProjectDB, PromptType
 from domain.dispatcher import (
     ComponentConfigChangeEvent,
     ComponentType,
@@ -39,7 +39,6 @@ from domain.services.schemas.project import (
     ProjectSchema,
     ProjectsListSchema,
     ProjectUpdateSchema,
-    PromptMode,
 )
 from domain.services.schemas.reader import ReaderConfig
 from domain.services.schemas.writer import WriterConfig
@@ -281,7 +280,7 @@ class ProjectService(BaseService):
         return PipelineConfig(
             project_id=project.id,
             device=project_device,
-            prompt_mode=PromptMode(project.prompt_mode),
+            prompt_mode=PromptType(project.prompt_mode),
             reader=reader_cfg,
             processor=processor_cfg,
             writer=writer_cfg,

--- a/application/backend/app/domain/services/project.py
+++ b/application/backend/app/domain/services/project.py
@@ -39,6 +39,7 @@ from domain.services.schemas.project import (
     ProjectSchema,
     ProjectsListSchema,
     ProjectUpdateSchema,
+    PromptMode,
 )
 from domain.services.schemas.reader import ReaderConfig
 from domain.services.schemas.writer import WriterConfig
@@ -280,6 +281,7 @@ class ProjectService(BaseService):
         return PipelineConfig(
             project_id=project.id,
             device=project_device,
+            prompt_mode=PromptMode(project.prompt_mode),
             reader=reader_cfg,
             processor=processor_cfg,
             writer=writer_cfg,

--- a/application/backend/app/domain/services/prompt.py
+++ b/application/backend/app/domain/services/prompt.py
@@ -25,10 +25,11 @@ from domain.repositories.processor import ProcessorRepository
 from domain.repositories.project import ProjectRepository
 from domain.repositories.prompt import PromptRepository
 from domain.services.base import BaseService
-from domain.services.schemas.annotation import AnnotationSchema
+from domain.services.schemas.annotation import AnnotationSchema, AnnotationType
 from domain.services.schemas.base import Pagination
 from domain.services.schemas.mappers.annotation import annotations_db_to_schemas
 from domain.services.schemas.mappers.label import label_db_to_schema
+from domain.services.schemas.mappers.processor import get_supported_annotation_types, processor_db_to_schema
 from domain.services.schemas.mappers.prompt import (
     deduplicate_annotations,
     prompt_create_schema_to_db,
@@ -36,8 +37,11 @@ from domain.services.schemas.mappers.prompt import (
     prompt_update_schema_to_db,
     prompts_db_to_schemas,
 )
+from domain.services.schemas.processor import ModelType
+from domain.services.schemas.project import PromptMode
 from domain.services.schemas.prompt import (
     PromptCreateSchema,
+    PromptListItemSchema,
     PromptSchema,
     PromptsListSchema,
     PromptUpdateSchema,
@@ -96,21 +100,41 @@ class PromptService(BaseService):
         Raises:
             ResourceNotFoundError: If the project does not exist.
         """
-        self._ensure_project(project_id)
-        db_prompts, total_count = self.prompt_repository.list_with_pagination_by_project(
-            project_id=project_id, offset=offset, limit=limit
-        )
-
+        project = self._ensure_project(project_id)
+        current_prompt_mode = PromptMode(project.prompt_mode)
+        db_prompt_type = PromptType.TEXT if current_prompt_mode == PromptMode.TEXT else PromptType.VISUAL
+        db_prompts = self.prompt_repository.list_all_by_project(project_id=project_id, prompt_type=db_prompt_type)
         prompts = prompts_db_to_schemas(db_prompts, include_thumbnail=True)
 
+        # for visual mode, filter further by the active model's supported annotation types
+        if current_prompt_mode == PromptMode.VISUAL:
+            active_model_db = self.processor_repository.get_active_in_project(project_id)
+            if active_model_db:
+                active_model = processor_db_to_schema(active_model_db)
+                supported_annotation_types = get_supported_annotation_types(ModelType(active_model.config.model_type))
+                prompts = self._filter_visual_prompts_by_annotation_type(prompts, supported_annotation_types)
+
+        result = prompts[offset : offset + limit]
+
         pagination = Pagination(
-            count=len(prompts),
-            total=total_count,
+            count=len(result),
+            total=len(prompts),
             offset=offset,
             limit=limit,
         )
 
-        return PromptsListSchema(prompts=prompts, pagination=pagination)
+        return PromptsListSchema(prompts=result, pagination=pagination)
+
+    @staticmethod
+    def _filter_visual_prompts_by_annotation_type(
+        prompts: list[PromptSchema | PromptListItemSchema], supported_types: set[AnnotationType]
+    ) -> list[PromptSchema | PromptListItemSchema]:
+        """Keep only visual prompts that have annotations matching supported types."""
+        filtered = []
+        for prompt in prompts:
+            if all(ann.config.type in supported_types for ann in prompt.annotations):
+                filtered.append(prompt)
+        return filtered
 
     def get_prompt(self, project_id: UUID, prompt_id: UUID) -> PromptSchema:
         """

--- a/application/backend/app/domain/services/prompt.py
+++ b/application/backend/app/domain/services/prompt.py
@@ -38,7 +38,6 @@ from domain.services.schemas.mappers.prompt import (
     prompts_db_to_schemas,
 )
 from domain.services.schemas.processor import ModelType
-from domain.services.schemas.project import PromptMode
 from domain.services.schemas.prompt import (
     PromptCreateSchema,
     PromptListItemSchema,
@@ -101,13 +100,14 @@ class PromptService(BaseService):
             ResourceNotFoundError: If the project does not exist.
         """
         project = self._ensure_project(project_id)
-        current_prompt_mode = PromptMode(project.prompt_mode)
-        db_prompt_type = PromptType.TEXT if current_prompt_mode == PromptMode.TEXT else PromptType.VISUAL
-        db_prompts = self.prompt_repository.list_all_by_project(project_id=project_id, prompt_type=db_prompt_type)
+        current_prompt_type = PromptType(project.prompt_mode)
+        db_prompts = self.prompt_repository.list_by_project_and_type(
+            project_id=project_id, prompt_type=current_prompt_type
+        )
         prompts = prompts_db_to_schemas(db_prompts, include_thumbnail=True)
 
         # for visual mode, filter further by the active model's supported annotation types
-        if current_prompt_mode == PromptMode.VISUAL:
+        if current_prompt_type == PromptType.VISUAL:
             active_model_db = self.processor_repository.get_active_in_project(project_id)
             if active_model_db:
                 active_model = processor_db_to_schema(active_model_db)

--- a/application/backend/app/domain/services/prompt.py
+++ b/application/backend/app/domain/services/prompt.py
@@ -25,7 +25,7 @@ from domain.repositories.processor import ProcessorRepository
 from domain.repositories.project import ProjectRepository
 from domain.repositories.prompt import PromptRepository
 from domain.services.base import BaseService
-from domain.services.schemas.annotation import AnnotationSchema, Point
+from domain.services.schemas.annotation import AnnotationSchema
 from domain.services.schemas.base import Pagination
 from domain.services.schemas.mappers.annotation import annotations_db_to_schemas
 from domain.services.schemas.mappers.label import label_db_to_schema
@@ -101,10 +101,7 @@ class PromptService(BaseService):
             project_id=project_id, offset=offset, limit=limit
         )
 
-        # Denormalize coordinates for visual prompts
-        denormalized_prompts = [self._denormalization(project_id=project_id, data=prompt) for prompt in db_prompts]
-
-        prompts = prompts_db_to_schemas(denormalized_prompts, include_thumbnail=True)
+        prompts = prompts_db_to_schemas(db_prompts, include_thumbnail=True)
 
         pagination = Pagination(
             count=len(prompts),
@@ -134,8 +131,7 @@ class PromptService(BaseService):
         if not prompt:
             logger.error("Prompt not found: id=%s project_id=%s", prompt_id, project_id)
             raise ResourceNotFoundError(resource_type=ResourceType.PROMPT, resource_id=str(prompt_id))
-        denormalized_prompt = self._denormalization(project_id=project_id, data=prompt)
-        return prompt_db_to_schema(denormalized_prompt, include_thumbnail=False)
+        return prompt_db_to_schema(prompt, include_thumbnail=False)
 
     def create_prompt(self, project_id: UUID, create_data: PromptCreateSchema) -> PromptSchema:
         """
@@ -202,21 +198,16 @@ class PromptService(BaseService):
 
             height, width = frame.shape[:2]
 
-            logger.debug("Normalizing prompt data for project_id=%s", project_id)
-            normalized_data = self._normalization(create_data, height, width)
-
-            original_count = len(normalized_data.annotations)
-            normalized_data.annotations = deduplicate_annotations(normalized_data.annotations, height, width)
-            if len(normalized_data.annotations) < original_count:
+            original_count = len(create_data.annotations)
+            create_data.annotations = deduplicate_annotations(create_data.annotations, height, width)
+            if len(create_data.annotations) < original_count:
                 logger.info(
                     "Removed %d duplicate annotations from visual prompt creation request",
-                    original_count - len(normalized_data.annotations),
+                    original_count - len(create_data.annotations),
                 )
 
-            self._validate_annotation_labels(normalized_data.annotations, project_id)
-            thumbnail = self._generate_thumbnail(project_id, normalized_data.annotations, frame)
-
-            create_data = normalized_data
+            self._validate_annotation_labels(create_data.annotations, project_id)
+            thumbnail = self._generate_thumbnail(project_id, create_data.annotations, frame)
 
         try:
             with self.db_transaction():
@@ -385,19 +376,14 @@ class PromptService(BaseService):
                             resource_id=str(frame_id),
                             message=f"Failed to read frame {frame_id}",
                         )
-
                 height, width = frame.shape[:2]
-
-                normalized_data = self._normalization(update_data, height, width)
-
-                original_count = len(normalized_data.annotations)
-                normalized_data.annotations = deduplicate_annotations(normalized_data.annotations, height, width)
-                if len(normalized_data.annotations) < original_count:
+                original_count = len(update_data.annotations)
+                update_data.annotations = deduplicate_annotations(update_data.annotations, height, width)
+                if len(update_data.annotations) < original_count:
                     logger.info(
                         "Removed %d duplicate annotations from visual prompt update request",
-                        original_count - len(normalized_data.annotations),
+                        original_count - len(update_data.annotations),
                     )
-                update_data.annotations = normalized_data.annotations
 
             self._validate_annotation_labels(update_data.annotations, project_id)
             regenerate_thumbnail = True
@@ -542,43 +528,3 @@ class PromptService(BaseService):
                     component_id=active_processor.id,
                 )
             )
-
-    @staticmethod
-    def _normalization(  #todo process rectangles as well?
-        data: VisualPromptCreateSchema | VisualPromptUpdateSchema, height: int, width: int
-    ) -> VisualPromptCreateSchema | VisualPromptUpdateSchema:
-        """Normalize pixel coordinates to [0, 1] range."""
-        if data.annotations is not None:
-            for annotation in data.annotations:
-                normalized_points = [Point(x=point.x / width, y=point.y / height) for point in annotation.config.points]
-                annotation.config.points = normalized_points
-
-        return data
-
-    def _denormalization(self, project_id: UUID, data: PromptDB) -> PromptDB:  #todo process rectangles as well?
-        """Denormalize coordinates from [0, 1] range to pixel coordinates."""
-
-        # Skip denormalization for text prompts
-        if data.type == PromptType.TEXT:
-            return data
-
-        frame = self.frame_repository.read_frame(project_id=project_id, frame_id=data.frame_id)
-        if frame is None:
-            raise ResourceNotFoundError(
-                resource_type=ResourceType.FRAME,
-                resource_id=str(data.frame_id),
-            )
-        height, width = frame.shape[:2]
-
-        for annotation in data.annotations:
-            points = annotation.config.get("points")
-            denormalized_points = []
-            for point in points:
-                denormalized_point = {
-                    "x": int(point["x"] * width),
-                    "y": int(point["y"] * height),
-                }
-                denormalized_points.append(denormalized_point)
-            annotation.config = {**annotation.config, "points": denormalized_points}
-
-        return data

--- a/application/backend/app/domain/services/prompt.py
+++ b/application/backend/app/domain/services/prompt.py
@@ -544,7 +544,7 @@ class PromptService(BaseService):
             )
 
     @staticmethod
-    def _normalization(
+    def _normalization(  #todo process rectangles as well?
         data: VisualPromptCreateSchema | VisualPromptUpdateSchema, height: int, width: int
     ) -> VisualPromptCreateSchema | VisualPromptUpdateSchema:
         """Normalize pixel coordinates to [0, 1] range."""
@@ -555,7 +555,7 @@ class PromptService(BaseService):
 
         return data
 
-    def _denormalization(self, project_id: UUID, data: PromptDB) -> PromptDB:
+    def _denormalization(self, project_id: UUID, data: PromptDB) -> PromptDB:  #todo process rectangles as well?
         """Denormalize coordinates from [0, 1] range to pixel coordinates."""
 
         # Skip denormalization for text prompts

--- a/application/backend/app/domain/services/schemas/annotation.py
+++ b/application/backend/app/domain/services/schemas/annotation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 20277 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import StrEnum
@@ -35,7 +35,7 @@ class RectangleAnnotation(BaseModel):
         "json_schema_extra": {
             "example": {
                 "type": "rectangle",
-                "points": [{"x": 0.1, "y": 0.1}, {"x": 0.5, "y": 0.5}],
+                "points": [{"x": 1, "y": 1}, {"x": 77, "y": 77}],
             }
         }
     }
@@ -49,7 +49,7 @@ class PolygonAnnotation(BaseModel):
         "json_schema_extra": {
             "example": {
                 "type": "polygon",
-                "points": [{"x": 0.1, "y": 0.1}, {"x": 0.5, "y": 0.1}, {"x": 0.5, "y": 0.5}, {"x": 0.1, "y": 0.5}],
+                "points": [{"x": 1, "y": 1}, {"x": 77, "y": 1}, {"x": 77, "y": 77}, {"x": 1, "y": 77}],
             }
         }
     }

--- a/application/backend/app/domain/services/schemas/annotation.py
+++ b/application/backend/app/domain/services/schemas/annotation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 20277 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import StrEnum

--- a/application/backend/app/domain/services/schemas/mappers/mask.py
+++ b/application/backend/app/domain/services/schemas/mappers/mask.py
@@ -9,7 +9,7 @@ def polygons_to_masks(polygons: list[PolygonAnnotation], image_height: int, imag
     Convert multiple polygon annotations to a stacked array of binary masks.
 
     Args:
-        polygons: List of PolygonAnnotation objects with normalized coordinates (0.0-1.0)
+        polygons: List of PolygonAnnotation objects with pixel coordinates
         image_height: Height of the output masks in pixels
         image_width: Width of the output masks in pixels
 
@@ -26,14 +26,9 @@ def polygons_to_masks(polygons: list[PolygonAnnotation], image_height: int, imag
     masks = np.zeros((len(polygons), image_height, image_width), dtype=np.uint8)
 
     for i, polygon in enumerate(polygons):
-        pixel_points = np.array(
-            [[int(pt.x * image_width), int(pt.y * image_height)] for pt in polygon.points],
-            dtype=np.int32,
-        )
+        pixel_points = np.array([[int(pt.x), int(pt.y)] for pt in polygon.points], dtype=np.int32)
         mask = np.zeros((image_height, image_width), dtype=np.uint8)
         cv2.fillPoly(mask, [pixel_points], (1,))
         masks[i] = mask
 
     return masks
-
-#todo process rectangles as well

--- a/application/backend/app/domain/services/schemas/mappers/mask.py
+++ b/application/backend/app/domain/services/schemas/mappers/mask.py
@@ -35,3 +35,5 @@ def polygons_to_masks(polygons: list[PolygonAnnotation], image_height: int, imag
         masks[i] = mask
 
     return masks
+
+#todo process rectangles as well

--- a/application/backend/app/domain/services/schemas/mappers/processor.py
+++ b/application/backend/app/domain/services/schemas/mappers/processor.py
@@ -5,9 +5,11 @@ from collections.abc import Iterable
 from uuid import UUID
 
 from domain.db.models import ProcessorDB
+from domain.services.schemas.annotation import AnnotationType
 from domain.services.schemas.base import Pagination
 from domain.services.schemas.processor import (
     MatcherConfig,
+    ModelType,
     PerDinoConfig,
     ProcessorCreateSchema,
     ProcessorListSchema,
@@ -89,3 +91,20 @@ SUPPORTED_MODELS_METADATA: list[SupportedModelMetadataSchema] = [
         supported_prompt_types=[SupportedPromptType.TEXT, SupportedPromptType.VISUAL_RECTANGLE],
     ),
 ]
+
+PROMPT_TYPE_TO_ANNOTATION_TYPE: dict[SupportedPromptType, AnnotationType] = {
+    SupportedPromptType.VISUAL_POLYGON: AnnotationType.POLYGON,
+    SupportedPromptType.VISUAL_RECTANGLE: AnnotationType.RECTANGLE,
+}
+
+
+def get_supported_annotation_types(model_type: ModelType) -> set[AnnotationType]:
+    """Derive supported annotation types for a model from SUPPORTED_MODELS_METADATA."""
+    for metadata in SUPPORTED_MODELS_METADATA:
+        if metadata.default_config.model_type == model_type:
+            return {
+                PROMPT_TYPE_TO_ANNOTATION_TYPE[pt]
+                for pt in metadata.supported_prompt_types
+                if pt in PROMPT_TYPE_TO_ANNOTATION_TYPE
+            }
+    return set()

--- a/application/backend/app/domain/services/schemas/mappers/processor.py
+++ b/application/backend/app/domain/services/schemas/mappers/processor.py
@@ -74,23 +74,23 @@ def processors_db_to_list_items(
     return ProcessorListSchema(models=items, pagination=pagination)
 
 
-SUPPORTED_MODELS_METADATA: list[SupportedModelMetadataSchema] = [
-    SupportedModelMetadataSchema(
+SUPPORTED_MODELS_METADATA: dict[ModelType, SupportedModelMetadataSchema] = {
+    ModelType.MATCHER: SupportedModelMetadataSchema(
         default_config=MatcherConfig(), supported_prompt_types=[SupportedPromptType.VISUAL_POLYGON]
     ),
-    SupportedModelMetadataSchema(
+    ModelType.PERDINO: SupportedModelMetadataSchema(
         default_config=PerDinoConfig(),
         supported_prompt_types=[SupportedPromptType.VISUAL_POLYGON],
     ),
-    SupportedModelMetadataSchema(
+    ModelType.SOFT_MATCHER: SupportedModelMetadataSchema(
         default_config=SoftMatcherConfig(),
         supported_prompt_types=[SupportedPromptType.VISUAL_POLYGON],
     ),
-    SupportedModelMetadataSchema(
+    ModelType.SAM3: SupportedModelMetadataSchema(
         default_config=Sam3Config(),
         supported_prompt_types=[SupportedPromptType.TEXT, SupportedPromptType.VISUAL_RECTANGLE],
     ),
-]
+}
 
 PROMPT_TYPE_TO_ANNOTATION_TYPE: dict[SupportedPromptType, AnnotationType] = {
     SupportedPromptType.VISUAL_POLYGON: AnnotationType.POLYGON,
@@ -100,11 +100,11 @@ PROMPT_TYPE_TO_ANNOTATION_TYPE: dict[SupportedPromptType, AnnotationType] = {
 
 def get_supported_annotation_types(model_type: ModelType) -> set[AnnotationType]:
     """Derive supported annotation types for a model from SUPPORTED_MODELS_METADATA."""
-    for metadata in SUPPORTED_MODELS_METADATA:
-        if metadata.default_config.model_type == model_type:
-            return {
-                PROMPT_TYPE_TO_ANNOTATION_TYPE[pt]
-                for pt in metadata.supported_prompt_types
-                if pt in PROMPT_TYPE_TO_ANNOTATION_TYPE
-            }
-    return set()
+    metadata = SUPPORTED_MODELS_METADATA.get(model_type)
+    if metadata is None:
+        return set()
+    return {
+        PROMPT_TYPE_TO_ANNOTATION_TYPE[pt]
+        for pt in metadata.supported_prompt_types
+        if pt in PROMPT_TYPE_TO_ANNOTATION_TYPE
+    }

--- a/application/backend/app/domain/services/schemas/mappers/processor.py
+++ b/application/backend/app/domain/services/schemas/mappers/processor.py
@@ -12,6 +12,7 @@ from domain.services.schemas.processor import (
     ProcessorCreateSchema,
     ProcessorListSchema,
     ProcessorSchema,
+    Sam3Config,
     SoftMatcherConfig,
     SupportedModelMetadataSchema,
     SupportedPromptType,
@@ -83,8 +84,8 @@ SUPPORTED_MODELS_METADATA: list[SupportedModelMetadataSchema] = [
         default_config=SoftMatcherConfig(),
         supported_prompt_types=[SupportedPromptType.VISUAL_POLYGON],
     ),
-    # SupportedModelMetadataSchema(  #todo will be enabled in the following tasks
-    #     default_config=Sam3Config(),
-    #     supported_prompt_types=[SupportedPromptType.TEXT, SupportedPromptType.VISUAL_RECTANGLE],
-    # ),
+    SupportedModelMetadataSchema(
+        default_config=Sam3Config(),
+        supported_prompt_types=[SupportedPromptType.TEXT, SupportedPromptType.VISUAL_RECTANGLE],
+    ),
 ]

--- a/application/backend/app/domain/services/schemas/mappers/prompt.py
+++ b/application/backend/app/domain/services/schemas/mappers/prompt.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Iterable
+from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -12,7 +13,7 @@ from torchvision import tv_tensors
 
 from domain.db.models import AnnotationDB, PromptDB, PromptType
 from domain.errors import ServiceError
-from domain.services.schemas.annotation import AnnotationSchema, AnnotationType
+from domain.services.schemas.annotation import AnnotationSchema, AnnotationType, RectangleAnnotation
 from domain.services.schemas.mappers.annotation import annotations_db_to_schemas
 from domain.services.schemas.mappers.mask import polygons_to_masks
 from domain.services.schemas.prompt import (
@@ -143,17 +144,114 @@ def prompt_update_schema_to_db(prompt_db: PromptDB, schema: PromptUpdateSchema) 
     return prompt_db
 
 
+@dataclass
+class _AnnotationGroupResult:
+    """Intermediate result from processing a group of annotations by type."""
+
+    categories: list[str] = field(default_factory=list)
+    category_ids: list[int] = field(default_factory=list)
+    is_reference: list[bool] = field(default_factory=list)
+    n_shot: list[int] = field(default_factory=list)
+    masks: list[np.ndarray] = field(default_factory=list)
+    bboxes: list[list[float]] = field(default_factory=list)
+
+
+def _group_annotations_by_label(annotations: list[tuple[AnnotationSchema, Any]]) -> dict[UUID, list[Any]]:
+    """Group annotation configs by label ID."""
+    groups: dict[UUID, list[Any]] = {}
+    for ann, config in annotations:
+        groups.setdefault(ann.label_id, []).append(config)
+    return groups
+
+
+def _process_polygon_groups(
+    label_groups: dict[UUID, list[Any]],
+    label_to_category_id: dict[UUID, int],
+    label_shot_counts: dict[UUID, int],
+    height: int,
+    width: int,
+) -> _AnnotationGroupResult:
+    """Convert polygon annotations grouped by label into masks with metadata.
+
+    Args:
+        label_groups: Mapping from label UUID to list of PolygonAnnotation configs
+        label_to_category_id: Mapping from label UUID to category ID
+        label_shot_counts: Current shot count per label (modified in-place)
+        height: Image height in pixels
+        width: Image width in pixels
+
+    Returns:
+        Result containing masks and associated metadata
+    """
+    result = _AnnotationGroupResult()
+
+    for label_id, polygons in sorted(label_groups.items(), key=lambda x: str(x[0])):
+        if not polygons:
+            continue
+
+        instance_masks = polygons_to_masks(polygons, height, width)
+        semantic_mask = np.any(instance_masks, axis=0).astype(np.uint8)
+
+        category_id = label_to_category_id[label_id]
+        current_shot = label_shot_counts.get(label_id, 0)
+
+        result.masks.append(semantic_mask)
+        result.categories.append(str(label_id))
+        result.category_ids.append(category_id)
+        result.is_reference.append(True)
+        result.n_shot.append(current_shot)
+
+        label_shot_counts[label_id] = current_shot + 1
+
+    return result
+
+
+def _process_rectangle_groups(
+    label_groups: dict[UUID, list[RectangleAnnotation]],
+    label_to_category_id: dict[UUID, int],
+    label_shot_counts: dict[UUID, int],
+) -> _AnnotationGroupResult:
+    """Convert rectangle annotations grouped by label into bounding boxes with metadata.
+
+    Args:
+        label_groups: Mapping from label UUID to list of RectangleAnnotation configs
+        label_to_category_id: Mapping from label UUID to category ID
+        label_shot_counts: Current shot count per label (modified in-place)
+
+    Returns:
+        Result containing bboxes and associated metadata
+    """
+    result = _AnnotationGroupResult()
+
+    for label_id, rects in sorted(label_groups.items(), key=lambda x: str(x[0])):
+        if not rects:
+            continue
+
+        category_id = label_to_category_id[label_id]
+        current_shot = label_shot_counts.get(label_id, 0)
+
+        for rect in rects:
+            result.bboxes.append([rect.points[0].x, rect.points[0].y, rect.points[1].x, rect.points[1].y])
+            result.categories.append(str(label_id))
+            result.category_ids.append(category_id)
+            result.is_reference.append(True)
+            result.n_shot.append(current_shot)
+
+        label_shot_counts[label_id] = current_shot + 1
+
+    return result
+
+
 def visual_prompt_to_sample(
     prompt: PromptDB,
     frame: np.ndarray,
     label_to_category_id: dict[UUID, int],
     label_shot_counts: dict[UUID, int],
 ) -> Sample:
-    """
-    Convert a visual prompt to a Sample with merged semantic masks.
+    """Convert a visual prompt to a Sample with masks and/or bounding boxes.
 
-    Multiple annotations of the same label are merged into a single semantic mask.
-    One image = one shot per category.
+    Polygon annotations are merged into semantic masks (one per label).
+    Rectangle annotations are converted to bounding boxes in [x1, y1, x2, y2] format.
 
     Args:
         prompt: Visual prompt with annotations
@@ -162,7 +260,7 @@ def visual_prompt_to_sample(
         label_shot_counts: Current shot count per label (modified in-place)
 
     Returns:
-        Sample with merged masks, one per unique label in the prompt
+        Sample with masks and/or bboxes, one entry per unique label in the prompt
 
     Example:
         Prompt with 3 car annotations + 2 person annotations:
@@ -180,62 +278,47 @@ def visual_prompt_to_sample(
         )
 
     polygon_annotations = [(ann, ann.config) for ann in annotations if ann.config.type == AnnotationType.POLYGON]
-    if not polygon_annotations:  #todo process rectangles as well
-        raise ServiceError("Cannot create training sample: visual prompt must have at least one polygon annotation.")
+    rectangle_annotations = [(ann, ann.config) for ann in annotations if ann.config.type == AnnotationType.RECTANGLE]
+
+    if not polygon_annotations and not rectangle_annotations:
+        raise ServiceError("Cannot create training sample: visual prompt must have at least one annotation.")
 
     # Convert frame: HWC numpy → CHW tensor
     frame_chw = tv_tensors.Image(from_numpy(frame).permute(2, 0, 1))
     height, width = frame_chw.shape[-2:]
 
-    # Group annotations by label_id
-    label_groups: dict[UUID, list[Any]] = {}
-    for ann, polygon in polygon_annotations:
-        if ann.label_id not in label_groups:
-            label_groups[ann.label_id] = []
-        label_groups[ann.label_id].append(polygon)
+    # Process each annotation type
+    polygon_result = _process_polygon_groups(
+        _group_annotations_by_label(polygon_annotations),
+        label_to_category_id,
+        label_shot_counts,
+        height,
+        width,
+    )
+    rect_result = _process_rectangle_groups(
+        _group_annotations_by_label(rectangle_annotations),
+        label_to_category_id,
+        label_shot_counts,
+    )
 
-    all_masks = []
-    categories = []
-    category_ids = []
-    is_reference = []
-    n_shot = []
+    # Merge results
+    categories = polygon_result.categories + rect_result.categories
+    category_ids = polygon_result.category_ids + rect_result.category_ids
+    is_reference = polygon_result.is_reference + rect_result.is_reference
+    n_shot = polygon_result.n_shot + rect_result.n_shot
 
-    for label_id, polygons in sorted(label_groups.items(), key=lambda x: str(x[0])):
-        if not polygons:
-            continue
+    if not categories:
+        raise ServiceError(f"No valid annotations for prompt {prompt.id} after processing")
 
-        # Convert all polygons to masks and merge into a single semantic mask
-        instance_masks = polygons_to_masks(polygons, height, width)
-        semantic_mask = np.any(instance_masks, axis=0).astype(np.uint8)  # (H, W) boolean
-
-        category_id = label_to_category_id[label_id]
-        category_name = str(label_id)
-
-        # Get the current shot number for this label (from previous prompts)
-        current_shot = label_shot_counts.get(label_id, 0)
-
-        # One merged semantic mask per label = one shot
-        all_masks.append(semantic_mask)
-        categories.append(category_name)
-        category_ids.append(category_id)
-        is_reference.append(True)
-        n_shot.append(current_shot)
-
-        # Increment by 1 per image-category pair
-        label_shot_counts[label_id] = current_shot + 1
-
-    if not all_masks:
-        raise ServiceError(f"No valid masks for prompt {prompt.id} after merging")
-
-    # Stack masks: (N_categories, H, W) - one mask per category
-    masks = np.stack(all_masks, axis=0)
-    category_ids_array = np.array(category_ids, dtype=np.int32)
+    masks = np.stack(polygon_result.masks, axis=0) if polygon_result.masks else None
+    bboxes = np.array(rect_result.bboxes, dtype=np.float32) if rect_result.bboxes else None
 
     return Sample(
         image=frame_chw,
         masks=masks,
+        bboxes=bboxes,
         categories=categories,
-        category_ids=category_ids_array,
+        category_ids=np.array(category_ids, dtype=np.int32),
         is_reference=is_reference,
         n_shot=n_shot,
         image_path=str(prompt.frame_id),
@@ -246,17 +329,16 @@ def deduplicate_annotations(
     annotations: list[AnnotationSchema], image_height: int, image_width: int, iou_threshold: float = 0.9
 ) -> list[AnnotationSchema]:
     """
-    Remove duplicate or highly overlapping annotations based on polygon similarity.
+    Remove duplicate or highly overlapping annotations.
 
-    Uses IoU (Intersection over Union) to identify similar masks.
+    Uses IoU (Intersection over Union) to identify similar shapes.
     Keeps the first occurrence when duplicates are found.
-    Only processes polygon annotations; other types are kept as-is.
 
     Args:
         annotations: List of annotations to deduplicate
         image_height: Height in pixels for mask generation
         image_width: Width in pixels for mask generation
-        iou_threshold: IoU threshold above which polygons are considered duplicates (default: 0.9)
+        iou_threshold: IoU threshold above which annotations are considered duplicates (default: 0.9)
 
     Returns:
         List of unique annotations with duplicates removed
@@ -303,3 +385,35 @@ def _calculate_mask_iou(mask1: np.ndarray, mask2: np.ndarray) -> float:
         return 0.0
 
     return float(intersection / union)
+
+
+def _calculate_rect_iou(rect1: RectangleAnnotation, rect2: RectangleAnnotation) -> float:
+    """Calculate IoU between two rectangle annotations.
+
+    Args:
+        rect1: First rectangle annotation (two points: top-left and bottom-right)
+        rect2: Second rectangle annotation (two points: top-left and bottom-right)
+
+    Returns:
+        IoU score between 0 and 1
+    """
+    x1_min, y1_min = rect1.points[0].x, rect1.points[0].y
+    x1_max, y1_max = rect1.points[1].x, rect1.points[1].y
+
+    x2_min, y2_min = rect2.points[0].x, rect2.points[0].y
+    x2_max, y2_max = rect2.points[1].x, rect2.points[1].y
+
+    inter_x_min = max(x1_min, x2_min)
+    inter_y_min = max(y1_min, y2_min)
+    inter_x_max = min(x1_max, x2_max)
+    inter_y_max = min(y1_max, y2_max)
+
+    inter_area = max(0.0, inter_x_max - inter_x_min) * max(0.0, inter_y_max - inter_y_min)
+    area1 = (x1_max - x1_min) * (y1_max - y1_min)
+    area2 = (x2_max - x2_min) * (y2_max - y2_min)
+    union_area = area1 + area2 - inter_area
+
+    if union_area == 0:
+        return 0.0
+
+    return inter_area / union_area

--- a/application/backend/app/domain/services/schemas/mappers/prompt.py
+++ b/application/backend/app/domain/services/schemas/mappers/prompt.py
@@ -159,7 +159,7 @@ def filter_prompts_by_annotation_type(
 
 
 @dataclass
-class _AnnotationGroupResult:
+class AnnotationGroupResult:
     """Intermediate result from processing a group of annotations by type."""
 
     categories: list[str] = field(default_factory=list)
@@ -185,7 +185,7 @@ def _process_polygon_groups(
     label_shot_counts: dict[UUID, int],
     height: int,
     width: int,
-) -> _AnnotationGroupResult:
+) -> AnnotationGroupResult:
     """Convert polygon annotations grouped by label into masks with metadata.
 
     Args:
@@ -198,7 +198,7 @@ def _process_polygon_groups(
     Returns:
         Result containing masks and associated metadata
     """
-    result = _AnnotationGroupResult()
+    result = AnnotationGroupResult()
 
     for label_id, polygons in sorted(label_groups.items(), key=lambda x: str(x[0])):
         if not polygons:
@@ -226,7 +226,7 @@ def _process_rectangle_groups(
     label_to_category_id: dict[UUID, int],
     label_id_to_name: dict[UUID, str],
     label_shot_counts: dict[UUID, int],
-) -> _AnnotationGroupResult:
+) -> AnnotationGroupResult:
     """Convert rectangle annotations grouped by label into bounding boxes with metadata.
 
     Args:
@@ -237,7 +237,7 @@ def _process_rectangle_groups(
     Returns:
         Result containing bboxes and associated metadata
     """
-    result = _AnnotationGroupResult()
+    result = AnnotationGroupResult()
 
     for label_id, rects in sorted(label_groups.items(), key=lambda x: str(x[0])):
         if not rects:

--- a/application/backend/app/domain/services/schemas/mappers/prompt.py
+++ b/application/backend/app/domain/services/schemas/mappers/prompt.py
@@ -180,7 +180,7 @@ def visual_prompt_to_sample(
         )
 
     polygon_annotations = [(ann, ann.config) for ann in annotations if ann.config.type == AnnotationType.POLYGON]
-    if not polygon_annotations:
+    if not polygon_annotations:  #todo process rectangles as well
         raise ServiceError("Cannot create training sample: visual prompt must have at least one polygon annotation.")
 
     # Convert frame: HWC numpy → CHW tensor

--- a/application/backend/app/domain/services/schemas/mappers/prompt.py
+++ b/application/backend/app/domain/services/schemas/mappers/prompt.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
@@ -144,6 +144,20 @@ def prompt_update_schema_to_db(prompt_db: PromptDB, schema: PromptUpdateSchema) 
     return prompt_db
 
 
+def filter_prompts_by_annotation_type(
+    prompts: Sequence[PromptDB], supported_types: set[AnnotationType]
+) -> list[PromptDB]:
+    """Return only prompts whose annotations match the supported annotation types."""
+    filtered_prompts = []
+    for prompt in prompts:
+        matching_annotations = [
+            ann for ann in prompt.annotations if AnnotationType(ann.config.get("type")) in supported_types
+        ]
+        if matching_annotations:
+            filtered_prompts.append(prompt)
+    return filtered_prompts
+
+
 @dataclass
 class _AnnotationGroupResult:
     """Intermediate result from processing a group of annotations by type."""
@@ -167,6 +181,7 @@ def _group_annotations_by_label(annotations: list[tuple[AnnotationSchema, Any]])
 def _process_polygon_groups(
     label_groups: dict[UUID, list[Any]],
     label_to_category_id: dict[UUID, int],
+    label_id_to_name: dict[UUID, str],
     label_shot_counts: dict[UUID, int],
     height: int,
     width: int,
@@ -196,7 +211,7 @@ def _process_polygon_groups(
         current_shot = label_shot_counts.get(label_id, 0)
 
         result.masks.append(semantic_mask)
-        result.categories.append(str(label_id))
+        result.categories.append(label_id_to_name.get(label_id, str(label_id)))
         result.category_ids.append(category_id)
         result.is_reference.append(True)
         result.n_shot.append(current_shot)
@@ -209,6 +224,7 @@ def _process_polygon_groups(
 def _process_rectangle_groups(
     label_groups: dict[UUID, list[RectangleAnnotation]],
     label_to_category_id: dict[UUID, int],
+    label_id_to_name: dict[UUID, str],
     label_shot_counts: dict[UUID, int],
 ) -> _AnnotationGroupResult:
     """Convert rectangle annotations grouped by label into bounding boxes with metadata.
@@ -232,7 +248,7 @@ def _process_rectangle_groups(
 
         for rect in rects:
             result.bboxes.append([rect.points[0].x, rect.points[0].y, rect.points[1].x, rect.points[1].y])
-            result.categories.append(str(label_id))
+            result.categories.append(label_id_to_name.get(label_id, str(label_id)))
             result.category_ids.append(category_id)
             result.is_reference.append(True)
             result.n_shot.append(current_shot)
@@ -246,7 +262,9 @@ def visual_prompt_to_sample(
     prompt: PromptDB,
     frame: np.ndarray,
     label_to_category_id: dict[UUID, int],
+    label_id_to_name: dict[UUID, str],
     label_shot_counts: dict[UUID, int],
+    supported_annotation_types: set[AnnotationType],
 ) -> Sample:
     """Convert a visual prompt to a Sample with masks and/or bounding boxes.
 
@@ -257,7 +275,9 @@ def visual_prompt_to_sample(
         prompt: Visual prompt with annotations
         frame: RGB image as numpy array (H, W, C)
         label_to_category_id: Mapping from label UUID to category ID (shared across batch)
+        label_id_to_name: Mapping from label UUID to label name
         label_shot_counts: Current shot count per label (modified in-place)
+        supported_annotation_types: Set of supported annotation types to include in the sample
 
     Returns:
         Sample with masks and/or bboxes, one entry per unique label in the prompt
@@ -277,11 +297,17 @@ def visual_prompt_to_sample(
             f"Cannot convert visual prompt to sample: prompt {prompt.id} has no valid annotations with labels"
         )
 
-    polygon_annotations = [(ann, ann.config) for ann in annotations if ann.config.type == AnnotationType.POLYGON]
-    rectangle_annotations = [(ann, ann.config) for ann in annotations if ann.config.type == AnnotationType.RECTANGLE]
+    supported_annotations = [ann for ann in annotations if ann.config.type in supported_annotation_types]
 
-    if not polygon_annotations and not rectangle_annotations:
+    if not supported_annotations:
         raise ServiceError("Cannot create training sample: visual prompt must have at least one annotation.")
+
+    polygon_annotations = [
+        (ann, ann.config) for ann in supported_annotations if ann.config.type == AnnotationType.POLYGON
+    ]
+    rectangle_annotations = [
+        (ann, ann.config) for ann in supported_annotations if ann.config.type == AnnotationType.RECTANGLE
+    ]
 
     # Convert frame: HWC numpy → CHW tensor
     frame_chw = tv_tensors.Image(from_numpy(frame).permute(2, 0, 1))
@@ -291,6 +317,7 @@ def visual_prompt_to_sample(
     polygon_result = _process_polygon_groups(
         _group_annotations_by_label(polygon_annotations),
         label_to_category_id,
+        label_id_to_name,
         label_shot_counts,
         height,
         width,
@@ -298,6 +325,7 @@ def visual_prompt_to_sample(
     rect_result = _process_rectangle_groups(
         _group_annotations_by_label(rectangle_annotations),
         label_to_category_id,
+        label_id_to_name,
         label_shot_counts,
     )
 

--- a/application/backend/app/domain/services/schemas/pipeline.py
+++ b/application/backend/app/domain/services/schemas/pipeline.py
@@ -5,9 +5,9 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from domain.db.models import PromptType
 from domain.services.schemas.device import Device
 from domain.services.schemas.processor import ModelConfig
-from domain.services.schemas.project import PromptMode
 from domain.services.schemas.reader import ReaderConfig
 from domain.services.schemas.writer import WriterConfig
 
@@ -15,7 +15,7 @@ from domain.services.schemas.writer import WriterConfig
 class PipelineConfig(BaseModel):
     project_id: UUID
     device: Device = Device.CPU
-    prompt_mode: PromptMode = PromptMode.VISUAL
+    prompt_mode: PromptType = PromptType.VISUAL
     reader: ReaderConfig | None = None
     writer: WriterConfig | None = None
     processor: ModelConfig | None = None

--- a/application/backend/app/domain/services/schemas/pipeline.py
+++ b/application/backend/app/domain/services/schemas/pipeline.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from domain.services.schemas.device import Device
 from domain.services.schemas.processor import ModelConfig
+from domain.services.schemas.project import PromptMode
 from domain.services.schemas.reader import ReaderConfig
 from domain.services.schemas.writer import WriterConfig
 
@@ -14,6 +15,7 @@ from domain.services.schemas.writer import WriterConfig
 class PipelineConfig(BaseModel):
     project_id: UUID
     device: Device = Device.CPU
+    prompt_mode: PromptMode = PromptMode.VISUAL
     reader: ReaderConfig | None = None
     writer: WriterConfig | None = None
     processor: ModelConfig | None = None

--- a/application/backend/app/domain/services/schemas/processor.py
+++ b/application/backend/app/domain/services/schemas/processor.py
@@ -131,7 +131,10 @@ class SoftMatcherConfig(BaseModelConfig):
 
 
 class Sam3Config(BaseModel):
-    """Configuration for SAM3 visual or text-prompted segmentation model."""
+    """
+    Configuration for SAM3 visual or text-prompted segmentation model.
+    NOTE: Currently, SAM3 does not work well with torch.bfloat16 precision.
+    """
 
     model_type: Literal[ModelType.SAM3] = ModelType.SAM3
     confidence_threshold: float = Field(default=0.5, gt=0.0, lt=1.0)
@@ -150,7 +153,9 @@ class Sam3Config(BaseModel):
     }
 
 
-ModelConfig = Annotated[PerDinoConfig | MatcherConfig | SoftMatcherConfig, Field(discriminator="model_type")]
+ModelConfig = Annotated[
+    PerDinoConfig | MatcherConfig | SoftMatcherConfig | Sam3Config, Field(discriminator="model_type")
+]
 
 
 class SupportedPromptType(StrEnum):

--- a/application/backend/app/domain/services/schemas/project.py
+++ b/application/backend/app/domain/services/schemas/project.py
@@ -1,39 +1,31 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import StrEnum
-
 from pydantic import BaseModel, Field
 
+from domain.db.models import PromptType
 from domain.services.schemas.base import BaseIDPayload, BaseIDSchema, PaginatedResponse
 from domain.services.schemas.device import Device
-
-
-class PromptMode(StrEnum):
-    """Active prompt mode selected in the UI."""
-
-    TEXT = "text"
-    VISUAL = "visual"
 
 
 class ProjectCreateSchema(BaseIDPayload):
     name: str = Field(max_length=80, min_length=1)
     device: Device = Device.AUTO
-    prompt_mode: PromptMode = PromptMode.VISUAL
+    prompt_mode: PromptType = PromptType.VISUAL
 
 
 class ProjectUpdateSchema(BaseModel):
     name: str | None = Field(max_length=80, min_length=1, default=None)
     active: bool | None = None
     device: Device | None = None
-    prompt_mode: PromptMode | None = None
+    prompt_mode: PromptType | None = None
 
 
 class ProjectSchema(BaseIDSchema):
     name: str
     active: bool
     device: Device
-    prompt_mode: PromptMode
+    prompt_mode: PromptType
 
 
 class ProjectsListSchema(PaginatedResponse):

--- a/application/backend/app/domain/services/schemas/prompt.py
+++ b/application/backend/app/domain/services/schemas/prompt.py
@@ -44,10 +44,10 @@ class VisualPromptCreateSchema(BaseIDPayload):
                         "config": {
                             "type": "polygon",
                             "points": [
-                                {"x": 0.1, "y": 0.1},
-                                {"x": 0.5, "y": 0.1},
-                                {"x": 0.5, "y": 0.5},
-                                {"x": 0.1, "y": 0.5},
+                                {"x": 1, "y": 1},
+                                {"x": 5, "y": 1},
+                                {"x": 5, "y": 5},
+                                {"x": 1, "y": 5},
                             ],
                         },
                         "label_id": "123e4567-e89b-12d3-a456-426614174001",
@@ -96,10 +96,10 @@ class VisualPromptUpdateSchema(BaseModel):
                         "config": {
                             "type": "polygon",
                             "points": [
-                                {"x": 0.1, "y": 0.1},
-                                {"x": 0.5, "y": 0.1},
-                                {"x": 0.5, "y": 0.5},
-                                {"x": 0.1, "y": 0.5},
+                                {"x": 1, "y": 1},
+                                {"x": 5, "y": 1},
+                                {"x": 5, "y": 5},
+                                {"x": 1, "y": 5},
                             ],
                         },
                         "label_id": "123e4567-e89b-12d3-a456-426614174001",

--- a/application/backend/app/domain/services/thumbnail.py
+++ b/application/backend/app/domain/services/thumbnail.py
@@ -30,8 +30,7 @@ settings = get_settings()
 
 
 def generate_thumbnail(frame: np.ndarray, annotations: list[tuple[AnnotationSchema, LabelSchema]]) -> str:
-    """
-    Generate a thumbnail with annotation overlays.
+    """Generate a thumbnail with annotation overlays.
 
     Args:
         frame: Original frame as numpy array
@@ -41,11 +40,16 @@ def generate_thumbnail(frame: np.ndarray, annotations: list[tuple[AnnotationSche
         Base64-encoded data URI of the thumbnail with JPEG encoding
     """
     try:
+        orig_height, orig_width = frame.shape[:2]
         thumbnail = _resize_frame_to_thumbnail_size(frame)
-        height, width = thumbnail.shape[:2]
+        thumb_height, thumb_width = thumbnail.shape[:2]
+
+        scale_x = thumb_width / orig_width
+        scale_y = thumb_height / orig_height
+
         line_thickness = max(
             settings.thumbnail_min_line_thickness,
-            int(min(height, width) * settings.thumbnail_line_thickness_ratio),
+            int(min(thumb_height, thumb_width) * settings.thumbnail_line_thickness_ratio),
         )
 
         # create overlay for semi-transparent annotations
@@ -57,11 +61,11 @@ def generate_thumbnail(frame: np.ndarray, annotations: list[tuple[AnnotationSche
 
             if annotation.type == AnnotationType.RECTANGLE:
                 annotation_overlay = _draw_filled_rectangle(
-                    annotation_overlay, annotation, color_bgr, width, height, line_thickness
+                    annotation_overlay, annotation, color_bgr, scale_x, scale_y, line_thickness
                 )
             elif annotation.type == AnnotationType.POLYGON:
                 annotation_overlay = _draw_filled_polygon(
-                    annotation_overlay, annotation, color_bgr, width, height, line_thickness
+                    annotation_overlay, annotation, color_bgr, scale_x, scale_y, line_thickness
                 )
             else:
                 logger.warning(f"Unsupported annotation type: {annotation.type}")
@@ -107,26 +111,25 @@ def _draw_filled_rectangle(
     overlay: np.ndarray,
     rect: RectangleAnnotation,
     color_bgr: tuple[int, int, int],
-    image_width: int,
-    image_height: int,
+    scale_x: float,
+    scale_y: float,
     border_thickness: int,
 ) -> np.ndarray:
-    """
-    Draw a rectangle annotation with semi-transparent fill and opaque border.
+    """Draw a rectangle annotation with semi-transparent fill and opaque border.
 
     Args:
         overlay: Image overlay to draw on
-        rect: Rectangle annotation with normalized coordinates
+        rect: Rectangle annotation with pixel coordinates (x1, y1, x2, y2)
         color_bgr: Color in BGR format
-        image_width: Width of the image in pixels
-        image_height: Height of the image in pixels
+        scale_x: Horizontal scale factor (thumbnail_width / original_width)
+        scale_y: Vertical scale factor (thumbnail_height / original_height)
         border_thickness: Thickness of the rectangle border
 
     Returns:
         Overlay with rectangle drawn
     """
-    top_left = (int(rect.points[0].x * image_width), int(rect.points[0].y * image_height))
-    bottom_right = (int(rect.points[1].x * image_width), int(rect.points[1].y * image_height))
+    top_left = (int(rect.points[0].x * scale_x), int(rect.points[0].y * scale_y))
+    bottom_right = (int(rect.points[1].x * scale_x), int(rect.points[1].y * scale_y))
 
     # draw filled rectangle
     cv2.rectangle(overlay, top_left, bottom_right, color_bgr, -1)
@@ -141,26 +144,25 @@ def _draw_filled_polygon(
     overlay: np.ndarray,
     polygon: PolygonAnnotation,
     color_bgr: tuple[int, int, int],
-    image_width: int,
-    image_height: int,
+    scale_x: float,
+    scale_y: float,
     border_thickness: int,
 ) -> np.ndarray:
-    """
-    Draw a polygon annotation with semi-transparent fill and opaque border.
+    """Draw a polygon annotation with semi-transparent fill and opaque border.
 
     Args:
         overlay: Image overlay to draw on
-        polygon: Polygon annotation with normalized coordinates
+        polygon: Polygon annotation with pixel coordinates
         color_bgr: Color in BGR format
-        image_width: Width of the image in pixels
-        image_height: Height of the image in pixels
+        scale_x: Horizontal scale factor (thumbnail_width / original_width)
+        scale_y: Vertical scale factor (thumbnail_height / original_height)
         border_thickness: Thickness of the polygon border
 
     Returns:
         Overlay with polygon drawn
     """
     pixel_points = np.array(
-        [[int(pt.x * image_width), int(pt.y * image_height)] for pt in polygon.points],
+        [[int(pt.x * scale_x), int(pt.y * scale_y)] for pt in polygon.points],
         dtype=np.int32,
     )
 

--- a/application/backend/app/runtime/components.py
+++ b/application/backend/app/runtime/components.py
@@ -7,7 +7,6 @@ from abc import ABC, abstractmethod
 from instantlearn.data.base.batch import Batch
 from sqlalchemy.orm import Session, sessionmaker
 
-from domain.services.project import ProjectService
 from domain.services.schemas.device import AvailableDeviceSchema
 from domain.services.schemas.pipeline import PipelineConfig
 from domain.services.schemas.reader import ReaderConfig

--- a/application/backend/app/runtime/components.py
+++ b/application/backend/app/runtime/components.py
@@ -3,13 +3,15 @@
 
 import logging
 from abc import ABC, abstractmethod
-from uuid import UUID
 
 from instantlearn.data.base.batch import Batch
 from sqlalchemy.orm import Session, sessionmaker
 
 from domain.services.project import ProjectService
 from domain.services.schemas.device import AvailableDeviceSchema
+from domain.services.schemas.pipeline import PipelineConfig
+from domain.services.schemas.reader import ReaderConfig
+from domain.services.schemas.writer import WriterConfig
 from runtime.core.components.factories.model import ModelFactory
 from runtime.core.components.factories.reader import StreamReaderFactory
 from runtime.core.components.factories.writer import StreamWriterFactory
@@ -23,13 +25,13 @@ logger = logging.getLogger(__name__)
 
 class ComponentFactory(ABC):
     @abstractmethod
-    def create_source(self, project_id: UUID) -> Source: ...
+    def create_source(self, reader_cfg: ReaderConfig) -> Source: ...
 
     @abstractmethod
-    def create_processor(self, project_id: UUID, reference_batch: Batch) -> Processor: ...
+    def create_processor(self, pipeline_cfg: PipelineConfig, reference_batch: Batch) -> Processor: ...
 
     @abstractmethod
-    def create_sink(self, project_id: UUID) -> Sink: ...
+    def create_sink(self, writer_cfg: WriterConfig) -> Sink: ...
 
 
 class DefaultComponentFactory(ComponentFactory):
@@ -41,31 +43,22 @@ class DefaultComponentFactory(ComponentFactory):
         self._session_factory = session_factory
         self._model_factory = ModelFactory(available_devices=available_devices)
 
-    def create_source(self, project_id: UUID) -> Source:
-        with self._session_factory() as session:
-            svc = ProjectService(session=session)
-            cfg = svc.get_pipeline_config(project_id)
-        return Source(StreamReaderFactory.create(cfg.reader))
+    def create_source(self, reader_cfg: ReaderConfig) -> Source:
+        return Source(StreamReaderFactory.create(reader_cfg))
 
-    def create_processor(self, project_id: UUID, reference_batch: Batch) -> Processor:
-        with self._session_factory() as session:
-            project_svc = ProjectService(session)
-            cfg = project_svc.get_pipeline_config(project_id)
-        logger.info("Creating processor with model config: %s", cfg.processor)
+    def create_processor(self, pipeline_cfg: PipelineConfig, reference_batch: Batch) -> Processor:
+        logger.info("Creating processor with model config: %s", pipeline_cfg.processor)
         settings = get_settings()
         return Processor(
             model_handler=self._model_factory.create(
                 reference_batch=reference_batch,
-                config=cfg.processor,
-                configured_device=cfg.device,
+                config=pipeline_cfg.processor,
+                configured_device=pipeline_cfg.device,
             ),
             batch_size=settings.processor_batch_size,
             frame_skip_interval=settings.processor_frame_skip_interval,
             frame_skip_amount=settings.processor_frame_skip_amount,
         )
 
-    def create_sink(self, project_id: UUID) -> Sink:
-        with self._session_factory() as session:
-            svc = ProjectService(session=session)
-            cfg = svc.get_pipeline_config(project_id)
-        return Sink(StreamWriterFactory.create(cfg.writer))
+    def create_sink(self, writer_cfg: WriterConfig) -> Sink:
+        return Sink(StreamWriterFactory.create(writer_cfg))

--- a/application/backend/app/runtime/components.py
+++ b/application/backend/app/runtime/components.py
@@ -24,13 +24,13 @@ logger = logging.getLogger(__name__)
 
 class ComponentFactory(ABC):
     @abstractmethod
-    def create_source(self, reader_cfg: ReaderConfig) -> Source: ...
+    def create_source(self, reader_cfg: ReaderConfig | None) -> Source: ...
 
     @abstractmethod
-    def create_processor(self, pipeline_cfg: PipelineConfig, reference_batch: Batch) -> Processor: ...
+    def create_processor(self, pipeline_cfg: PipelineConfig, reference_batch: Batch | None) -> Processor: ...
 
     @abstractmethod
-    def create_sink(self, writer_cfg: WriterConfig) -> Sink: ...
+    def create_sink(self, writer_cfg: WriterConfig | None) -> Sink: ...
 
 
 class DefaultComponentFactory(ComponentFactory):
@@ -42,10 +42,10 @@ class DefaultComponentFactory(ComponentFactory):
         self._session_factory = session_factory
         self._model_factory = ModelFactory(available_devices=available_devices)
 
-    def create_source(self, reader_cfg: ReaderConfig) -> Source:
+    def create_source(self, reader_cfg: ReaderConfig | None) -> Source:
         return Source(StreamReaderFactory.create(reader_cfg))
 
-    def create_processor(self, pipeline_cfg: PipelineConfig, reference_batch: Batch) -> Processor:
+    def create_processor(self, pipeline_cfg: PipelineConfig, reference_batch: Batch | None) -> Processor:
         logger.info("Creating processor with model config: %s", pipeline_cfg.processor)
         settings = get_settings()
         return Processor(
@@ -59,5 +59,5 @@ class DefaultComponentFactory(ComponentFactory):
             frame_skip_amount=settings.processor_frame_skip_amount,
         )
 
-    def create_sink(self, writer_cfg: WriterConfig) -> Sink:
+    def create_sink(self, writer_cfg: WriterConfig | None) -> Sink:
         return Sink(StreamWriterFactory.create(writer_cfg))

--- a/application/backend/app/runtime/core/components/broadcaster.py
+++ b/application/backend/app/runtime/core/components/broadcaster.py
@@ -134,7 +134,7 @@ class FrameBroadcaster[T]:
 
     def _handle_full_queue(self, consumer_name: str, queue: Queue[T], frame: T) -> None:
         """Handle a full queue by dropping the oldest frame and adding the new one."""
-        logger.warning(
+        logger.debug(
             "%s/%s full (%d/%d), dropping oldest frame", self.name, consumer_name, queue.qsize(), queue.maxsize
         )
         try:

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -1,8 +1,6 @@
 #  Copyright (C) 2025 Intel Corporation
 #  SPDX-License-Identifier: Apache-2.0
 
-from logging import getLogger
-
 from instantlearn.data.base.batch import Batch
 from instantlearn.models.matcher import Matcher
 from instantlearn.models.per_dino import PerDino
@@ -17,8 +15,6 @@ from runtime.core.components.models.passthrough_model import PassThroughModelHan
 from runtime.core.components.models.torch_model import TorchModelHandler
 from runtime.services.device import list_available_devices
 from settings import get_settings
-
-logger = getLogger(__name__)
 
 
 class DeviceResolver:
@@ -128,8 +124,6 @@ class ModelFactory:
                     device=selected_device,
                     prompt_mode=prompt_mode,
                 )
-                # todo rm logging or log debug batch
-                logger.info(f"Using SAM3 model with prompt mode: {prompt_mode}, reference batch: {reference_batch}")
                 return TorchModelHandler(model, reference_batch)
             case _:
                 return PassThroughModelHandler()

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -4,10 +4,12 @@
 from instantlearn.data.base.batch import Batch
 from instantlearn.models.matcher import Matcher
 from instantlearn.models.per_dino import PerDino
+from instantlearn.models.sam3 import SAM3, Sam3PromptMode
 from instantlearn.models.soft_matcher import SoftMatcher
 
 from domain.services.schemas.device import AvailableDeviceSchema, Device
 from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, SoftMatcherConfig
+from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from runtime.core.components.base import ModelHandler
 from runtime.core.components.models.openvino_model import OpenVINOModelHandler
 from runtime.core.components.models.passthrough_model import PassThroughModelHandler
@@ -111,6 +113,17 @@ class ModelFactory:
                     softmatching_bidirectional=config.softmatching_bidirectional,
                     precision=config.precision,
                     device=selected_device,
+                )
+                return TorchModelHandler(model, reference_batch)
+            case Sam3Config() as config:
+                has_bboxes = any(s.bboxes is not None for s in reference_batch.samples)
+                prompt_mode = Sam3PromptMode.VISUAL_EXEMPLAR if has_bboxes else Sam3PromptMode.CLASSIC
+                model = SAM3(
+                    confidence_threshold=config.confidence_threshold,
+                    resolution=config.resolution,
+                    precision=config.precision,
+                    device=selected_device,
+                    prompt_mode=prompt_mode,
                 )
                 return TorchModelHandler(model, reference_batch)
             case _:

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -10,8 +10,6 @@ from instantlearn.models.sam3 import SAM3, Sam3PromptMode
 from instantlearn.models.soft_matcher import SoftMatcher
 
 from domain.services.schemas.device import AvailableDeviceSchema, Device
-from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, SoftMatcherConfig
-from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from runtime.core.components.base import ModelHandler
 from runtime.core.components.models.openvino_model import OpenVINOModelHandler

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -1,15 +1,17 @@
 #  Copyright (C) 2025 Intel Corporation
 #  SPDX-License-Identifier: Apache-2.0
 
+from logging import getLogger
+
 from instantlearn.data.base.batch import Batch
 from instantlearn.models.matcher import Matcher
 from instantlearn.models.per_dino import PerDino
 from instantlearn.models.sam3 import SAM3, Sam3PromptMode
 from instantlearn.models.soft_matcher import SoftMatcher
-from logging import getLogger
-from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
+
 from domain.services.schemas.device import AvailableDeviceSchema, Device
 from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, SoftMatcherConfig
+from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from runtime.core.components.base import ModelHandler
 from runtime.core.components.models.openvino_model import OpenVINOModelHandler
@@ -17,7 +19,6 @@ from runtime.core.components.models.passthrough_model import PassThroughModelHan
 from runtime.core.components.models.torch_model import TorchModelHandler
 from runtime.services.device import list_available_devices
 from settings import get_settings
-
 
 logger = getLogger(__name__)
 
@@ -129,7 +130,7 @@ class ModelFactory:
                     device=selected_device,
                     prompt_mode=prompt_mode,
                 )
-                #todo rm logging or log debug batch
+                # todo rm logging or log debug batch
                 logger.info(f"Using SAM3 model with prompt mode: {prompt_mode}, reference batch: {reference_batch}")
                 return TorchModelHandler(model, reference_batch)
             case _:

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -6,7 +6,8 @@ from instantlearn.models.matcher import Matcher
 from instantlearn.models.per_dino import PerDino
 from instantlearn.models.sam3 import SAM3, Sam3PromptMode
 from instantlearn.models.soft_matcher import SoftMatcher
-
+from logging import getLogger
+from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from domain.services.schemas.device import AvailableDeviceSchema, Device
 from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, SoftMatcherConfig
 from domain.services.schemas.processor import MatcherConfig, ModelConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
@@ -16,6 +17,9 @@ from runtime.core.components.models.passthrough_model import PassThroughModelHan
 from runtime.core.components.models.torch_model import TorchModelHandler
 from runtime.services.device import list_available_devices
 from settings import get_settings
+
+
+logger = getLogger(__name__)
 
 
 class DeviceResolver:
@@ -125,6 +129,8 @@ class ModelFactory:
                     device=selected_device,
                     prompt_mode=prompt_mode,
                 )
+                #todo rm logging or log debug batch
+                logger.info(f"Using SAM3 model with prompt mode: {prompt_mode}, reference batch: {reference_batch}")
                 return TorchModelHandler(model, reference_batch)
             case _:
                 return PassThroughModelHandler()

--- a/application/backend/app/runtime/pipeline_manager.py
+++ b/application/backend/app/runtime/pipeline_manager.py
@@ -338,7 +338,7 @@ class PipelineManager:
             prompt_repo = PromptRepository(session=session)
             label_svc = LabelService(session=session)
 
-            db_prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=prompt_type)  #todo directly from db in normalized form - is it ok for inference in case of SAM3?
+            db_prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=prompt_type)
             if not db_prompts:
                 logger.info("No prompts found for project_id=%s, prompt_type=%s", project_id, prompt_type)
                 return None

--- a/application/backend/app/runtime/pipeline_manager.py
+++ b/application/backend/app/runtime/pipeline_manager.py
@@ -28,7 +28,6 @@ from domain.services.schemas.mappers.processor import get_supported_annotation_t
 from domain.services.schemas.mappers.prompt import filter_prompts_by_annotation_type, visual_prompt_to_sample
 from domain.services.schemas.pipeline import PipelineConfig
 from domain.services.schemas.processor import InputData, ModelType, OutputData
-from domain.services.schemas.project import PromptMode
 from domain.services.schemas.reader import FrameListResponse
 from runtime.components import ComponentFactory, DefaultComponentFactory
 from runtime.core.components.broadcaster import FrameBroadcaster, FrameSlot
@@ -122,7 +121,7 @@ class PipelineManager:
             prompt_repo = PromptRepository(session=session)
 
             vis_labels = label_svc.get_visualization_labels(project_id)
-            prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=PromptType.VISUAL)
+            prompts = prompt_repo.list_by_project_and_type(project_id=project_id, prompt_type=PromptType.VISUAL)
             all_label_ids: set[UUID] = set()
             for prompt in prompts:
                 all_label_ids.update(ann.label_id for ann in prompt.annotations)
@@ -173,7 +172,7 @@ class PipelineManager:
 
         model_type = ModelType(cfg.processor.model_type)
         # TODO For SAM3 with text prompt_mode, build a text-only batch - issue #758 enabling text prompts
-        if model_type == ModelType.SAM3 and cfg.prompt_mode == PromptMode.TEXT:
+        if model_type == ModelType.SAM3 and cfg.prompt_mode == PromptType.TEXT:
             logger.warning("Text prompts are not supported yet for SAM3: project_id=%s", cfg.project_id)
             return None
         #     return self.get_text_reference_batch(project_id)
@@ -371,7 +370,7 @@ class PipelineManager:
             prompt_repo = PromptRepository(session=session)
             label_svc = LabelService(session=session)
 
-            db_prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=PromptType.VISUAL)
+            db_prompts = prompt_repo.list_by_project_and_type(project_id=project_id, prompt_type=PromptType.VISUAL)
             if not db_prompts:
                 logger.info("No visual prompts found for project_id=%s", project_id)
                 return None

--- a/application/backend/app/runtime/pipeline_manager.py
+++ b/application/backend/app/runtime/pipeline_manager.py
@@ -167,8 +167,11 @@ class PipelineManager:
             logger.warning("No current pipeline config available to build a reference batch")
             return None
         cfg = self._current_config
-        model_type = ModelType(cfg.processor.model_type)
+        if cfg.processor is None:
+            logger.debug("No active processor configured, skipping reference batch: project_id=%s", cfg.project_id)
+            return None
 
+        model_type = ModelType(cfg.processor.model_type)
         # TODO For SAM3 with text prompt_mode, build a text-only batch - issue #758 enabling text prompts
         if model_type == ModelType.SAM3 and cfg.prompt_mode == PromptMode.TEXT:
             logger.warning("Text prompts are not supported yet for SAM3: project_id=%s", cfg.project_id)

--- a/application/backend/app/runtime/pipeline_manager.py
+++ b/application/backend/app/runtime/pipeline_manager.py
@@ -338,7 +338,7 @@ class PipelineManager:
             prompt_repo = PromptRepository(session=session)
             label_svc = LabelService(session=session)
 
-            db_prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=prompt_type)
+            db_prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=prompt_type)  #todo directly from db in normalized form - is it ok for inference in case of SAM3?
             if not db_prompts:
                 logger.info("No prompts found for project_id=%s, prompt_type=%s", project_id, prompt_type)
                 return None

--- a/application/backend/app/runtime/pipeline_manager.py
+++ b/application/backend/app/runtime/pipeline_manager.py
@@ -25,7 +25,8 @@ from domain.services.project import ProjectService
 from domain.services.schemas.label import VisualizationInfo
 from domain.services.schemas.mappers.prompt import visual_prompt_to_sample
 from domain.services.schemas.pipeline import PipelineConfig
-from domain.services.schemas.processor import InputData, OutputData
+from domain.services.schemas.processor import InputData, OutputData, Sam3Config
+from domain.services.schemas.project import PromptMode
 from domain.services.schemas.reader import FrameListResponse
 from runtime.components import ComponentFactory, DefaultComponentFactory
 from runtime.core.components.broadcaster import FrameBroadcaster, FrameSlot
@@ -159,6 +160,21 @@ class PipelineManager:
                         self._refresh_visualization_info(e.project_id)
                     logger.info("Pipeline components updated for project %s", e.project_id)
 
+    def _build_reference_batch(self, project_id: UUID) -> tuple[Batch, dict[int, str]] | None:
+        """Build the appropriate reference batch based on project config."""
+        with self._session_factory() as session:
+            svc = ProjectService(session=session)
+            cfg = svc.get_pipeline_config(project_id)
+
+        # TODO For SAM3 with text prompt_mode, build a text-only batch - issue #758 enabling text prompts
+        if isinstance(cfg.processor, Sam3Config) and cfg.prompt_mode == PromptMode.TEXT:
+            logger.warning("Text prompts are not supported yet for SAM3: project_id=%s", project_id)
+            return None
+        #     return self.get_text_reference_batch(project_id)
+
+        # all other models (and SAM3 with visual prompts) use visual batch
+        return self.get_reference_batch(project_id, PromptType.VISUAL)
+
     def _create_pipeline(self, project_id: UUID) -> Pipeline:
         """
         Create a new Pipeline instance with components built from the given configuration.
@@ -170,7 +186,7 @@ class PipelineManager:
             A fully initialized Pipeline instance (not yet started).
         """
         source = self._component_factory.create_source(project_id)
-        reference_batch, category_id_to_label_id = self.get_reference_batch(project_id, PromptType.VISUAL) or (None, {})
+        reference_batch, category_id_to_label_id = self._build_reference_batch(project_id) or (None, {})
         processor = self._component_factory.create_processor(project_id, reference_batch)
         sink = self._component_factory.create_sink(project_id)
 

--- a/application/backend/app/runtime/pipeline_manager.py
+++ b/application/backend/app/runtime/pipeline_manager.py
@@ -22,10 +22,12 @@ from domain.repositories.frame import FrameRepository
 from domain.repositories.prompt import PromptRepository
 from domain.services.label import LabelService
 from domain.services.project import ProjectService
+from domain.services.schemas.annotation import AnnotationType
 from domain.services.schemas.label import VisualizationInfo
-from domain.services.schemas.mappers.prompt import visual_prompt_to_sample
+from domain.services.schemas.mappers.processor import get_supported_annotation_types
+from domain.services.schemas.mappers.prompt import filter_prompts_by_annotation_type, visual_prompt_to_sample
 from domain.services.schemas.pipeline import PipelineConfig
-from domain.services.schemas.processor import InputData, OutputData, Sam3Config
+from domain.services.schemas.processor import InputData, ModelType, OutputData
 from domain.services.schemas.project import PromptMode
 from domain.services.schemas.reader import FrameListResponse
 from runtime.components import ComponentFactory, DefaultComponentFactory
@@ -66,7 +68,7 @@ class PipelineManager:
         self._pipeline: Pipeline | None = None
         self._current_config: PipelineConfig | None = None
         self._visualization_info: VisualizationInfo | None = None
-        self._visualization_lock = threading.Lock()
+        self._lock = threading.Lock()
 
     def start(self) -> None:
         """
@@ -76,10 +78,11 @@ class PipelineManager:
             svc = ProjectService(session=session, config_change_dispatcher=self._event_dispatcher)
             cfg = svc.get_active_pipeline_config()
         if cfg:
-            self._current_config = cfg
-            self._pipeline = self._create_pipeline(cfg.project_id)
-            self._refresh_visualization_info(cfg.project_id)
-            self._pipeline.start()
+            with self._lock:
+                self._current_config = cfg
+                self._pipeline = self._create_pipeline(cfg.project_id)
+                self._refresh_visualization_info(cfg.project_id)
+                self._pipeline.start()
             logger.info("Pipeline started: project_id=%s", cfg.project_id)
         else:
             logger.info("No active project found at startup.")
@@ -89,29 +92,30 @@ class PipelineManager:
         """
         Stop and dispose the running pipeline.
         """
-        if self._pipeline:
-            self._pipeline.stop()
-            self._pipeline = None
-        self._current_config = None
+        with self._lock:
+            if self._pipeline:
+                self._pipeline.stop()
+                self._pipeline = None
+            self._current_config = None
+            self._visualization_info = None
 
     def get_visualization_info(self, project_id: UUID) -> VisualizationInfo | None:
         """
         Get cached visualization info for the active pipeline.
         """
-        if self._pipeline is None:
-            raise PipelineNotActiveError("No active pipeline.")
-        if project_id != self._pipeline.project_id:
-            raise PipelineProjectMismatchError(
-                f"Project ID {project_id} does not match the active pipeline's project ID."
-            )
-        with self._visualization_lock:
+        with self._lock:
+            if self._pipeline is None:
+                raise PipelineNotActiveError("No active pipeline.")
+            if project_id != self._pipeline.project_id:
+                raise PipelineProjectMismatchError(
+                    f"Project ID {project_id} does not match the active pipeline's project ID."
+                )
             return self._visualization_info
 
     def _refresh_visualization_info(self, project_id: UUID) -> None:
         """
         Refresh cached visualization info from a database.
-
-        Called when a pipeline starts or prompts/labels change.
+        Called when a pipeline starts or prompts/labels change. Must be called while self._lock is held.
         """
         with self._session_factory() as session:
             label_svc = LabelService(session=session)
@@ -125,70 +129,72 @@ class PipelineManager:
 
             category_mappings = label_svc.build_category_mappings(all_label_ids)
 
-        with self._visualization_lock:
-            self._visualization_info = VisualizationInfo(
-                label_colors=vis_labels,
-                category_mappings=category_mappings,
-            )
+        self._visualization_info = VisualizationInfo(label_colors=vis_labels, category_mappings=category_mappings)
         logger.debug("Refreshed visualization info for project %s", project_id)
 
     def on_config_change(self, event: ConfigChangeEvent) -> None:
         """
         React to configuration change events.
         """
-        match event:
-            case ProjectActivationEvent() as e:
-                if self._pipeline:
-                    self._pipeline.stop()
-                self._pipeline = self._create_pipeline(e.project_id)
-                self._refresh_visualization_info(e.project_id)
-                self._pipeline.start()
-                logger.info("Pipeline started for activated project %s", e.project_id)
+        with self._lock:
+            match event:
+                case ProjectActivationEvent() as e:
+                    if self._pipeline:
+                        self._pipeline.stop()
+                    self._pipeline = self._create_pipeline(e.project_id)
+                    self._refresh_visualization_info(e.project_id)
+                    self._pipeline.start()
+                    logger.info("Pipeline started for activated project %s", e.project_id)
 
-            case ProjectDeactivationEvent() as e:
-                if self._pipeline and self._pipeline.project_id == e.project_id:
-                    self._pipeline.stop()
-                    self._current_config = None
-                    with self._visualization_lock:
+                case ProjectDeactivationEvent() as e:
+                    if self._pipeline and self._pipeline.project_id == e.project_id:
+                        self._pipeline.stop()
+                        self._pipeline = None
+                        self._current_config = None
                         self._visualization_info = None
-                    logger.info("Pipeline stopped due to project deactivation %s", e.project_id)
+                        logger.info("Pipeline stopped due to project deactivation %s", e.project_id)
 
-            case ComponentConfigChangeEvent() as e:
-                if self._pipeline and self._pipeline.project_id == e.project_id:
-                    self._update_pipeline_components(e.project_id, e.component_type)
-                    if e.component_type == ComponentType.PROCESSOR:
-                        self._refresh_visualization_info(e.project_id)
-                    logger.info("Pipeline components updated for project %s", e.project_id)
+                case ComponentConfigChangeEvent() as e:
+                    if self._pipeline and self._pipeline.project_id == e.project_id:
+                        self._update_pipeline_components(e.project_id, e.component_type)
+                        if e.component_type == ComponentType.PROCESSOR:
+                            self._refresh_visualization_info(e.project_id)
+                        logger.info("Pipeline components updated for project %s", e.project_id)
 
-    def _build_reference_batch(self, project_id: UUID) -> tuple[Batch, dict[int, str]] | None:
+    def _build_reference_batch(self) -> tuple[Batch, dict[int, str]] | None:
         """Build the appropriate reference batch based on project config."""
-        with self._session_factory() as session:
-            svc = ProjectService(session=session)
-            cfg = svc.get_pipeline_config(project_id)
+        if self._current_config is None:
+            logger.warning("No current pipeline config available to build a reference batch")
+            return None
+        cfg = self._current_config
+        model_type = ModelType(cfg.processor.model_type)
 
         # TODO For SAM3 with text prompt_mode, build a text-only batch - issue #758 enabling text prompts
-        if isinstance(cfg.processor, Sam3Config) and cfg.prompt_mode == PromptMode.TEXT:
-            logger.warning("Text prompts are not supported yet for SAM3: project_id=%s", project_id)
+        if model_type == ModelType.SAM3 and cfg.prompt_mode == PromptMode.TEXT:
+            logger.warning("Text prompts are not supported yet for SAM3: project_id=%s", cfg.project_id)
             return None
         #     return self.get_text_reference_batch(project_id)
 
         # all other models (and SAM3 with visual prompts) use visual batch
-        return self.get_reference_batch(project_id, PromptType.VISUAL)
+        supported_types = get_supported_annotation_types(model_type)
+        return self.get_visual_reference_batch(cfg.project_id, supported_types)
 
     def _create_pipeline(self, project_id: UUID) -> Pipeline:
         """
-        Create a new Pipeline instance with components built from the given configuration.
-
-        Args:
-            config: The pipeline configuration.
+        Create a new Pipeline instance with components from the given configuration.
+        Must be called while self._lock is held.
 
         Returns:
             A fully initialized Pipeline instance (not yet started).
         """
-        source = self._component_factory.create_source(project_id)
-        reference_batch, category_id_to_label_id = self._build_reference_batch(project_id) or (None, {})
-        processor = self._component_factory.create_processor(project_id, reference_batch)
-        sink = self._component_factory.create_sink(project_id)
+        with self._session_factory() as session:
+            svc = ProjectService(session=session)
+            cfg = svc.get_pipeline_config(project_id)
+        self._current_config = cfg
+        source = self._component_factory.create_source(cfg.reader)
+        reference_batch, category_id_to_label_id = self._build_reference_batch() or (None, {})
+        processor = self._component_factory.create_processor(cfg, reference_batch)
+        sink = self._component_factory.create_sink(cfg.writer)
 
         return (
             Pipeline(
@@ -213,19 +219,24 @@ class PipelineManager:
         if not self._pipeline:
             return
 
+        with self._session_factory() as session:
+            svc = ProjectService(session=session)
+            cfg = svc.get_pipeline_config(project_id)
+        self._current_config = cfg
+
         match component_type:
             case ComponentType.SOURCE:
-                source = self._component_factory.create_source(project_id)
+                source = self._component_factory.create_source(cfg.reader)
                 self._pipeline.set_source(source, True)
             case ComponentType.PROCESSOR:
-                reference_batch, category_id_to_label_id = self.get_reference_batch(project_id, PromptType.VISUAL) or (
+                reference_batch, category_id_to_label_id = self._build_reference_batch() or (
                     None,
                     {},
                 )
-                processor = self._component_factory.create_processor(project_id, reference_batch)
+                processor = self._component_factory.create_processor(cfg, reference_batch)
                 self._pipeline.set_processor(processor, True)
             case ComponentType.SINK:
-                sink = self._component_factory.create_sink(project_id)
+                sink = self._component_factory.create_sink(cfg.writer)
                 self._pipeline.set_sink(sink, True)
             case _ as unknown:
                 logger.error(f"Unknown component type {unknown}")
@@ -236,11 +247,12 @@ class PipelineManager:
         External consumers (e.g. WebRTC streams) can poll this slot without
         registering or unregistering — they simply read ``slot.latest``.
         """
-        if self._pipeline is None:
-            raise PipelineNotActiveError("No active pipeline.")
-        if project_id != self._pipeline.project_id:
-            raise PipelineProjectMismatchError("Project ID does not match the active pipeline's project ID.")
-        return self._pipeline.outbound_slot
+        with self._lock:
+            if self._pipeline is None:
+                raise PipelineNotActiveError("No active pipeline.")
+            if project_id != self._pipeline.project_id:
+                raise PipelineProjectMismatchError("Project ID does not match the active pipeline's project ID.")
+            return self._pipeline.outbound_slot
 
     def seek(self, project_id: UUID, index: int) -> None:
         """
@@ -256,12 +268,13 @@ class PipelineManager:
             SourceNotSeekableError: If the source doesn't support seeking.
             IndexError: If index is out of bounds.
         """
-        if self._pipeline is None:
-            raise PipelineNotActiveError("No active pipeline.")
-        if project_id != self._pipeline.project_id:
-            raise PipelineProjectMismatchError(
-                f"Project ID {project_id} does not match the active pipeline's project ID."
-            )
+        with self._lock:
+            if self._pipeline is None:
+                raise PipelineNotActiveError("No active pipeline.")
+            if project_id != self._pipeline.project_id:
+                raise PipelineProjectMismatchError(
+                    f"Project ID {project_id} does not match the active pipeline's project ID."
+                )
         try:
             self._pipeline.seek(index)
         except UnsupportedOperationError:
@@ -282,12 +295,13 @@ class PipelineManager:
             PipelineProjectMismatchError: If project_id doesn't match the active pipeline.
             SourceNotSeekableError: If the source doesn't support indexing.
         """
-        if self._pipeline is None:
-            raise PipelineNotActiveError("No active pipeline.")
-        if project_id != self._pipeline.project_id:
-            raise PipelineProjectMismatchError(
-                f"Project ID {project_id} does not match the active pipeline's project ID."
-            )
+        with self._lock:
+            if self._pipeline is None:
+                raise PipelineNotActiveError("No active pipeline.")
+            if project_id != self._pipeline.project_id:
+                raise PipelineProjectMismatchError(
+                    f"Project ID {project_id} does not match the active pipeline's project ID."
+                )
         try:
             return self._pipeline.get_frame_index()
         except UnsupportedOperationError:
@@ -310,12 +324,13 @@ class PipelineManager:
             PipelineProjectMismatchError: If project_id doesn't match the active pipeline.
             SourceNotSeekableError: If the source doesn't support frame listing.
         """
-        if self._pipeline is None:
-            raise PipelineNotActiveError("No active pipeline.")
-        if project_id != self._pipeline.project_id:
-            raise PipelineProjectMismatchError(
-                f"Project ID {project_id} does not match the active pipeline's project ID."
-            )
+        with self._lock:
+            if self._pipeline is None:
+                raise PipelineNotActiveError("No active pipeline.")
+            if project_id != self._pipeline.project_id:
+                raise PipelineProjectMismatchError(
+                    f"Project ID {project_id} does not match the active pipeline's project ID."
+                )
         try:
             return self._pipeline.list_frames(offset, limit)
         except UnsupportedOperationError:
@@ -331,45 +346,47 @@ class PipelineManager:
         Returns:
             UUID of the captured frame.
         """
-        if self._pipeline is None:
-            raise PipelineNotActiveError("No active pipeline.")
-        if project_id != self._pipeline.project_id:
-            raise PipelineProjectMismatchError(
-                f"Project ID {project_id} does not match the active pipeline's project ID."
-            )
+        with self._lock:
+            if self._pipeline is None:
+                raise PipelineNotActiveError("No active pipeline.")
+            if project_id != self._pipeline.project_id:
+                raise PipelineProjectMismatchError(
+                    f"Project ID {project_id} does not match the active pipeline's project ID."
+                )
         return self._pipeline.capture_frame()
 
-    def get_reference_batch(self, project_id: UUID, prompt_type: PromptType) -> tuple[Batch, dict[int, str]] | None:
+    def get_visual_reference_batch(
+        self, project_id: UUID, supported_annotation_types: set[AnnotationType]
+    ) -> tuple[Batch, dict[int, str]] | None:
         """
         Get all prompts of a specific type for a project, formatted for model training.
 
         Returns:
             Tuple of (Batch, category_id_to_label_id mapping), or None if no valid samples were found.
         """
-        if prompt_type == PromptType.TEXT:
-            logger.warning("Text prompts not supported for training data generation: project_id=%s", project_id)
-            return None
-
         with self._session_factory() as session:
             prompt_repo = PromptRepository(session=session)
             label_svc = LabelService(session=session)
 
-            db_prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=prompt_type)
+            db_prompts = prompt_repo.list_all_by_project(project_id=project_id, prompt_type=PromptType.VISUAL)
             if not db_prompts:
-                logger.info("No prompts found for project_id=%s, prompt_type=%s", project_id, prompt_type)
+                logger.info("No visual prompts found for project_id=%s", project_id)
                 return None
 
+            filtered_prompts = filter_prompts_by_annotation_type(db_prompts, supported_annotation_types)
+
             all_label_ids: set[UUID] = set()
-            for prompt in db_prompts:
+            for prompt in filtered_prompts:
                 all_label_ids.update(ann.label_id for ann in prompt.annotations)
 
             category_mappings = label_svc.build_category_mappings(all_label_ids)
+            label_id_to_name = label_svc.get_label_names(all_label_ids)
 
             # track shot counts across prompts
             label_shot_counts: dict[UUID, int] = {}
             samples = []
 
-            for prompt in db_prompts:
+            for prompt in filtered_prompts:
                 if not prompt.frame_id:
                     logger.warning("Visual prompt missing frame_id: prompt_id=%s", prompt.id)
                     continue
@@ -382,7 +399,12 @@ class PipelineManager:
 
                     frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                     sample = visual_prompt_to_sample(
-                        prompt, frame_rgb, category_mappings.label_to_category_id, label_shot_counts
+                        prompt,
+                        frame_rgb,
+                        category_mappings.label_to_category_id,
+                        label_id_to_name,
+                        label_shot_counts,
+                        supported_annotation_types,
                     )
                     samples.append(sample)
 

--- a/application/backend/app/runtime/webrtc/stream.py
+++ b/application/backend/app/runtime/webrtc/stream.py
@@ -74,7 +74,7 @@ class InferenceVideoStreamTrack(VideoStreamTrack):
 
             if output_data.trace:
                 output_data.trace.record_end("webrtc")
-                logger.info(output_data.trace.format_log())
+                logger.debug(output_data.trace.format_log())
 
         np_frame = self._last_frame if self._last_frame is not None else FALLBACK_FRAME
         frame = VideoFrame.from_ndarray(np_frame, format="rgb24")

--- a/application/backend/app/runtime/webrtc/visualizer.py
+++ b/application/backend/app/runtime/webrtc/visualizer.py
@@ -241,7 +241,7 @@ class InferenceVisualizer:
         resolver = CategoryResolver(visualization_info)
         renderers = self._build_renderers(resolver)
 
-        logger.info(f"Visualizing predictions: {output_data.results}") #todo cleanup
+        logger.info(f"Visualizing predictions: {output_data.results}")  # todo cleanup
         logger.debug("Visualizing %d predictions", len(output_data.results))
         for prediction in output_data.results:
             labels = prediction.get("pred_labels")

--- a/application/backend/app/runtime/webrtc/visualizer.py
+++ b/application/backend/app/runtime/webrtc/visualizer.py
@@ -241,7 +241,6 @@ class InferenceVisualizer:
         resolver = CategoryResolver(visualization_info)
         renderers = self._build_renderers(resolver)
 
-        logger.info(f"Visualizing predictions: {output_data.results}")  # todo cleanup
         logger.debug("Visualizing %d predictions", len(output_data.results))
         for prediction in output_data.results:
             labels = prediction.get("pred_labels")

--- a/application/backend/app/runtime/webrtc/visualizer.py
+++ b/application/backend/app/runtime/webrtc/visualizer.py
@@ -241,6 +241,7 @@ class InferenceVisualizer:
         resolver = CategoryResolver(visualization_info)
         renderers = self._build_renderers(resolver)
 
+        logger.info(f"Visualizing predictions: {output_data.results}") #todo cleanup
         logger.debug("Visualizing %d predictions", len(output_data.results))
         for prediction in output_data.results:
             labels = prediction.get("pred_labels")

--- a/application/backend/tests/integration/domain/repository/test_project_repository.py
+++ b/application/backend/tests/integration/domain/repository/test_project_repository.py
@@ -31,7 +31,7 @@ def test_add_and_get_by_id(repo, fxt_session, clean_after):
     assert fetched.name == "alpha"
     assert fetched.active is False
     assert fetched.device == "auto"
-    assert fetched.prompt_mode == "visual"
+    assert fetched.prompt_mode == "VISUAL"
 
 
 def test_get_by_id_not_found(repo, clean_after):

--- a/application/backend/tests/integration/domain/repository/test_prompt_repository.py
+++ b/application/backend/tests/integration/domain/repository/test_prompt_repository.py
@@ -148,7 +148,7 @@ def test_get_all_by_project(prompt_repo, fxt_session, clean_after):
     prompt_repo.add(other_prompt)
     fxt_session.commit()
 
-    result = prompt_repo.list_all_by_project(project_main.id)
+    result = prompt_repo.list_by_project_and_type(project_main.id)
     assert len(result) == 3
     assert {p.id for p in result} == {text_prompt.id, visual_prompt_1.id, visual_prompt_2.id}
 
@@ -166,15 +166,15 @@ def test_get_all_by_project_with_type_filter(prompt_repo, fxt_session, clean_aft
         prompt_repo.add(p)
     fxt_session.commit()
 
-    all_prompts = prompt_repo.list_all_by_project(project.id)
+    all_prompts = prompt_repo.list_by_project_and_type(project.id)
     assert len(all_prompts) == 3
 
-    text_prompts = prompt_repo.list_all_by_project(project.id, prompt_type=PromptType.TEXT)
+    text_prompts = prompt_repo.list_by_project_and_type(project.id, prompt_type=PromptType.TEXT)
     assert len(text_prompts) == 1
     assert text_prompts[0].id == text_prompt.id
     assert text_prompts[0].type == PromptType.TEXT
 
-    visual_prompts = prompt_repo.list_all_by_project(project.id, prompt_type=PromptType.VISUAL)
+    visual_prompts = prompt_repo.list_by_project_and_type(project.id, prompt_type=PromptType.VISUAL)
     assert len(visual_prompts) == 2
     assert {p.id for p in visual_prompts} == {visual_prompt_1.id, visual_prompt_2.id}
     assert all(p.type == PromptType.VISUAL for p in visual_prompts)
@@ -296,7 +296,7 @@ def test_multiple_visual_prompts_allowed(prompt_repo, fxt_session, clean_after):
         prompt_repo.add(prompt)
     fxt_session.commit()
 
-    result = prompt_repo.list_all_by_project(project.id)
+    result = prompt_repo.list_by_project_and_type(project.id)
     assert len(result) == 5
     assert all(p.type == PromptType.VISUAL for p in result)
 
@@ -393,7 +393,7 @@ def test_unique_frame_id_constraint(prompt_repo, fxt_session, clean_after):
     fxt_session.rollback()
 
     # verify only first prompt exists
-    all_prompts = prompt_repo.list_all_by_project(project.id)
+    all_prompts = prompt_repo.list_by_project_and_type(project.id)
     assert len(all_prompts) == 1
     assert all_prompts[0].frame_id == frame_id
 
@@ -416,6 +416,6 @@ def test_different_frames_allowed(prompt_repo, fxt_session, clean_after):
         prompt_repo.add(p)
     fxt_session.commit()
 
-    all_prompts = prompt_repo.list_all_by_project(project.id)
+    all_prompts = prompt_repo.list_by_project_and_type(project.id)
     assert len(all_prompts) == 3
     assert {p.frame_id for p in all_prompts} == {frame_id_1, frame_id_2, frame_id_3}

--- a/application/backend/tests/unit/api/endpoints/test_projects_endpoints.py
+++ b/application/backend/tests/unit/api/endpoints/test_projects_endpoints.py
@@ -27,7 +27,7 @@ SECOND_PROJECT_ID_STR = str(SECOND_PROJECT_ID)
 
 
 def assert_project_schema(
-    data: dict, project_id: str, name: str, active: bool = False, device: str = "cpu", prompt_mode: str = "visual"
+    data: dict, project_id: str, name: str, active: bool = False, device: str = "cpu", prompt_mode: str = "VISUAL"
 ):
     assert data["id"] == project_id
     assert data["name"] == name
@@ -82,7 +82,7 @@ def test_create_project(client, behavior, expected_status, expect_location, expe
         def create_project(self, payload):
             assert payload.name == "myproj"
             if behavior == "success":
-                return ProjectSchema(id=PROJECT_ID, name="myproj", active=True, device="cpu", prompt_mode="visual")
+                return ProjectSchema(id=PROJECT_ID, name="myproj", active=True, device="cpu", prompt_mode="VISUAL")
             if behavior == "conflict":
                 raise ResourceAlreadyExistsError(
                     resource_type=ResourceType.PROJECT,
@@ -127,7 +127,7 @@ class TestCreateProject:
             def create_project(self, payload):
                 assert payload.name == "myproj"
                 if behavior == "success":
-                    return ProjectSchema(id=PROJECT_ID, name="myproj", active=True, device="cpu", prompt_mode="visual")
+                    return ProjectSchema(id=PROJECT_ID, name="myproj", active=True, device="cpu", prompt_mode="VISUAL")
                 if behavior == "conflict":
                     raise ResourceAlreadyExistsError(
                         resource_type=ResourceType.PROJECT,
@@ -227,7 +227,7 @@ def test_get_active_project(client, behavior, expected_status):
 
         def get_active_project_info(self):
             if behavior == "success":
-                return ProjectSchema(id=PROJECT_ID, name="activeproj", active=True, device="cpu", prompt_mode="visual")
+                return ProjectSchema(id=PROJECT_ID, name="activeproj", active=True, device="cpu", prompt_mode="VISUAL")
             if behavior == "notfound":
                 raise ResourceNotFoundError(
                     resource_type=ResourceType.PROJECT,
@@ -268,8 +268,8 @@ def test_get_projects_list(client, behavior, expected_status, expected_count):
                 )
             if behavior == "some_projects":
                 projects = [
-                    ProjectSchema(id=PROJECT_ID, name="proj1", active=False, device="cpu", prompt_mode="visual"),
-                    ProjectSchema(id=SECOND_PROJECT_ID, name="proj2", active=False, device="cpu", prompt_mode="visual"),
+                    ProjectSchema(id=PROJECT_ID, name="proj1", active=False, device="cpu", prompt_mode="VISUAL"),
+                    ProjectSchema(id=SECOND_PROJECT_ID, name="proj2", active=False, device="cpu", prompt_mode="VISUAL"),
                 ]
                 return ProjectsListSchema(
                     projects=projects, pagination=Pagination(count=2, total=2, offset=offset, limit=limit)
@@ -307,7 +307,7 @@ def test_get_projects_list_with_pagination_params(client):
         def list_projects(self, offset=0, limit=20):
             assert offset == 10
             assert limit == 5
-            projects = [ProjectSchema(id=PROJECT_ID, name="proj1", active=False, device="cpu", prompt_mode="visual")]
+            projects = [ProjectSchema(id=PROJECT_ID, name="proj1", active=False, device="cpu", prompt_mode="VISUAL")]
             return ProjectsListSchema(projects=projects, pagination=Pagination(count=1, total=15, offset=10, limit=5))
 
     client.app.dependency_overrides[get_project_service] = lambda: FakeService(None, None)
@@ -339,7 +339,7 @@ def test_get_project(client, behavior, expected_status, expect_payload):
         def get_project(self, project_id: UUID):
             assert project_id == PROJECT_ID
             if behavior == "minimal":
-                return ProjectSchema(id=PROJECT_ID, name="minproj", active=False, device="cpu", prompt_mode="visual")
+                return ProjectSchema(id=PROJECT_ID, name="minproj", active=False, device="cpu", prompt_mode="VISUAL")
             if behavior == "notfound":
                 raise ResourceNotFoundError(resource_type=ResourceType.PROJECT, resource_id=str(project_id))
             if behavior == "error":
@@ -377,7 +377,7 @@ def test_update_project(client, behavior, expected_status):
             assert update_data.name == NEW_NAME
             assert update_data.device == "cuda"
             if behavior == "success":
-                return ProjectSchema(id=PROJECT_ID, name=NEW_NAME, active=False, device="cuda", prompt_mode="visual")
+                return ProjectSchema(id=PROJECT_ID, name=NEW_NAME, active=False, device="cuda", prompt_mode="VISUAL")
             if behavior == "notfound":
                 raise ResourceNotFoundError(resource_type=ResourceType.PROJECT, resource_id=str(project_id))
             if behavior == "conflict":

--- a/application/backend/tests/unit/api/endpoints/test_supported_models.py
+++ b/application/backend/tests/unit/api/endpoints/test_supported_models.py
@@ -60,7 +60,7 @@ class TestGetSupportedModels:
             ModelType.MATCHER,
             ModelType.PERDINO,
             ModelType.SOFT_MATCHER,
-            # ModelType.SAM3,
+            ModelType.SAM3,
         }
 
     def test_each_model_has_required_fields(self, client):
@@ -76,13 +76,13 @@ class TestGetSupportedModels:
         response = client.get("/api/v1/system/supported-models")
         body = response.json()
         assert "pagination" in body
-        assert body["pagination"]["total"] == 3
-        assert body["pagination"]["count"] == 3
+        assert body["pagination"]["total"] == 4
+        assert body["pagination"]["count"] == 4
 
     def test_response_is_parseable_by_schema(self, client):
         response = client.get("/api/v1/system/supported-models")
         parsed = SupportedModelsListSchema.model_validate(response.json())
-        assert len(parsed.models) == 3
+        assert len(parsed.models) == 4
 
 
 class TestMatcherModel:

--- a/application/backend/tests/unit/api/endpoints/test_supported_models.py
+++ b/application/backend/tests/unit/api/endpoints/test_supported_models.py
@@ -11,6 +11,7 @@ from domain.services.schemas.processor import (
     MatcherConfig,
     ModelType,
     PerDinoConfig,
+    Sam3Config,
     SoftMatcherConfig,
     SupportedModelsListSchema,
     SupportedPromptType,
@@ -167,41 +168,41 @@ class TestSoftMatcherModel:
         assert soft_matcher["default_config"]["encoder_model"] == expected.encoder_model
 
 
-# class TestSam3Model:
-#     """Verify SAM3 model metadata."""
-#
-#     def _get_sam3(self, client):
-#         response = client.get("/api/v1/system/supported-models")
-#         models = response.json()["models"]
-#         return next(m for m in models if m["default_config"]["model_type"] == ModelType.SAM3)
-#
-#     def test_sam3_prompt_types(self, client):
-#         sam3 = self._get_sam3(client)
-#
-#         assert set(sam3["supported_prompt_types"]) == {
-#             SupportedPromptType.TEXT,
-#             SupportedPromptType.VISUAL_RECTANGLE,
-#         }
-#
-#     def test_sam3_does_not_support_visual_polygon(self, client):
-#         sam3 = self._get_sam3(client)
-#
-#         assert SupportedPromptType.VISUAL_POLYGON not in sam3["supported_prompt_types"]
-#
-#     def test_sam3_default_config_matches_class_defaults(self, client):
-#         sam3 = self._get_sam3(client)
-#         expected = Sam3Config()
-#
-#         assert sam3["default_config"]["confidence_threshold"] == expected.confidence_threshold
-#         assert sam3["default_config"]["resolution"] == expected.resolution
-#         assert sam3["default_config"]["precision"] == expected.precision
-#
-#     def test_sam3_has_no_sam_or_encoder_fields(self, client):
-#         """SAM3 uses its own base — it has no sam_model / encoder_model fields."""
-#         sam3 = self._get_sam3(client)
-#
-#         assert "sam_model" not in sam3["default_config"]
-#         assert "encoder_model" not in sam3["default_config"]
+class TestSam3Model:
+    """Verify SAM3 model metadata."""
+
+    def _get_sam3(self, client):
+        response = client.get("/api/v1/system/supported-models")
+        models = response.json()["models"]
+        return next(m for m in models if m["default_config"]["model_type"] == ModelType.SAM3)
+
+    def test_sam3_prompt_types(self, client):
+        sam3 = self._get_sam3(client)
+
+        assert set(sam3["supported_prompt_types"]) == {
+            SupportedPromptType.TEXT,
+            SupportedPromptType.VISUAL_RECTANGLE,
+        }
+
+    def test_sam3_does_not_support_visual_polygon(self, client):
+        sam3 = self._get_sam3(client)
+
+        assert SupportedPromptType.VISUAL_POLYGON not in sam3["supported_prompt_types"]
+
+    def test_sam3_default_config_matches_class_defaults(self, client):
+        sam3 = self._get_sam3(client)
+        expected = Sam3Config()
+
+        assert sam3["default_config"]["confidence_threshold"] == expected.confidence_threshold
+        assert sam3["default_config"]["resolution"] == expected.resolution
+        assert sam3["default_config"]["precision"] == expected.precision
+
+    def test_sam3_has_no_sam_or_encoder_fields(self, client):
+        """SAM3 uses its own base — it has no sam_model / encoder_model fields."""
+        sam3 = self._get_sam3(client)
+
+        assert "sam_model" not in sam3["default_config"]
+        assert "encoder_model" not in sam3["default_config"]
 
 
 class TestPromptTypeCoverage:
@@ -218,25 +219,25 @@ class TestPromptTypeCoverage:
         }
         assert polygon_models == {ModelType.MATCHER, ModelType.PERDINO, ModelType.SOFT_MATCHER}
 
-    # def test_text_prompt_models(self, client):
-    #     response = client.get("/api/v1/system/supported-models")
-    #     models = response.json()["models"]
-    #
-    #     text_models = {
-    #         m["default_config"]["model_type"] for m in models if SupportedPromptType.TEXT in m["supported_prompt_types"]
-    #     }
-    #     assert text_models == {ModelType.SAM3}
+    def test_text_prompt_models(self, client):
+        response = client.get("/api/v1/system/supported-models")
+        models = response.json()["models"]
 
-    # def test_visual_rectangle_models(self, client):
-    #     response = client.get("/api/v1/system/supported-models")
-    #     models = response.json()["models"]
-    #
-    #     rect_models = {
-    #         m["default_config"]["model_type"]
-    #         for m in models
-    #         if SupportedPromptType.VISUAL_RECTANGLE in m["supported_prompt_types"]
-    #     }
-    #     assert rect_models == {ModelType.SAM3}
+        text_models = {
+            m["default_config"]["model_type"] for m in models if SupportedPromptType.TEXT in m["supported_prompt_types"]
+        }
+        assert text_models == {ModelType.SAM3}
+
+    def test_visual_rectangle_models(self, client):
+        response = client.get("/api/v1/system/supported-models")
+        models = response.json()["models"]
+
+        rect_models = {
+            m["default_config"]["model_type"]
+            for m in models
+            if SupportedPromptType.VISUAL_RECTANGLE in m["supported_prompt_types"]
+        }
+        assert rect_models == {ModelType.SAM3}
 
     def test_no_unknown_prompt_types(self, client):
         response = client.get("/api/v1/system/supported-models")

--- a/application/backend/tests/unit/domain/services/schemas/mappers/test_prompt_mapper.py
+++ b/application/backend/tests/unit/domain/services/schemas/mappers/test_prompt_mapper.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 import uuid
 from types import SimpleNamespace
 
@@ -30,19 +29,17 @@ class TestPromptMapper:
         project_id = uuid.uuid4()
         frame_id = uuid.uuid4()
         label_id = uuid.uuid4()
-
+        # Use pixel coordinates for the 480x640 frame
         config = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.1), Point(x=0.5, y=0.5), Point(x=0.1, y=0.5)],
+            points=[Point(x=64, y=48), Point(x=320, y=48), Point(x=320, y=240), Point(x=64, y=240)],
         )
-
         annotation_db = SimpleNamespace(
             id=uuid.uuid4(),
             config=config.model_dump(),
             label_id=label_id,
             prompt_id=prompt_id,
         )
-
         prompt_db = SimpleNamespace(
             id=prompt_id,
             type=PromptType.VISUAL,
@@ -51,38 +48,36 @@ class TestPromptMapper:
             project_id=project_id,
             annotations=[annotation_db],
         )
-
         label_to_category_id = {label_id: 0}
+        label_id_to_name = {label_id: "car"}
         label_shot_counts: dict[uuid.UUID, int] = {}
-
+        supported_annotation_types = {AnnotationType.POLYGON}
         result = visual_prompt_to_sample(
             prompt_db,
             frame=sample_frame,
             label_to_category_id=label_to_category_id,
+            label_id_to_name=label_id_to_name,
             label_shot_counts=label_shot_counts,
+            supported_annotation_types=supported_annotation_types,
         )
-
         assert result is not None
         assert isinstance(result, Sample)
         assert np.array_equal(result.image.permute(1, 2, 0).numpy(), sample_frame)
         assert len(result.categories) == 1
-        assert result.categories[0] == str(label_id)
+        assert result.categories[0] == "car"
         assert label_shot_counts[label_id] == 1
 
     def test_visual_prompt_to_sample_raises_error_without_polygons(self, sample_frame: np.ndarray) -> None:
         prompt_id = uuid.uuid4()
         frame_id = uuid.uuid4()
         label_id = uuid.uuid4()
-
-        config = RectangleAnnotation(type=AnnotationType.RECTANGLE, points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.5)])
-
+        config = RectangleAnnotation(type=AnnotationType.RECTANGLE, points=[Point(x=10, y=10), Point(x=50, y=50)])
         annotation_db = SimpleNamespace(
             id=uuid.uuid4(),
             config=config.model_dump(),
             label_id=label_id,
             prompt_id=prompt_id,
         )
-
         prompt_db = SimpleNamespace(
             id=prompt_id,
             type=PromptType.VISUAL,
@@ -91,16 +86,19 @@ class TestPromptMapper:
             project_id=uuid.uuid4(),
             annotations=[annotation_db],
         )
-
         label_to_category_id = {label_id: 0}
+        label_id_to_name = {label_id: "car"}
         label_shot_counts: dict[uuid.UUID, int] = {}
-
-        with pytest.raises(ServiceError, match="must have at least one polygon annotation"):
+        # Only polygons supported — rectangle should be filtered out
+        supported_annotation_types = {AnnotationType.POLYGON}
+        with pytest.raises(ServiceError, match="must have at least one annotation"):
             visual_prompt_to_sample(
                 prompt_db,
                 frame=sample_frame,
                 label_to_category_id=label_to_category_id,
+                label_id_to_name=label_id_to_name,
                 label_shot_counts=label_shot_counts,
+                supported_annotation_types=supported_annotation_types,
             )
 
     def test_visual_prompt_to_sample_with_multiple_polygons(self, sample_frame: np.ndarray) -> None:
@@ -108,15 +106,14 @@ class TestPromptMapper:
         frame_id = uuid.uuid4()
         label_id_1 = uuid.uuid4()
         label_id_2 = uuid.uuid4()
-
         config_1 = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.3, y=0.1), Point(x=0.3, y=0.3), Point(x=0.1, y=0.3)],
+            points=[Point(x=64, y=48), Point(x=192, y=48), Point(x=192, y=192), Point(x=64, y=192)],
         )
         config_2 = PolygonAnnotation(
-            type=AnnotationType.POLYGON, points=[Point(x=0.5, y=0.5), Point(x=0.7, y=0.7), Point(x=0.6, y=0.8)]
+            type=AnnotationType.POLYGON,
+            points=[Point(x=320, y=240), Point(x=448, y=336), Point(x=384, y=384)],
         )
-
         annotation_db_1 = SimpleNamespace(
             id=uuid.uuid4(),
             config=config_1.model_dump(),
@@ -129,7 +126,6 @@ class TestPromptMapper:
             label_id=label_id_2,
             prompt_id=prompt_id,
         )
-
         prompt_db = SimpleNamespace(
             id=prompt_id,
             type=PromptType.VISUAL,
@@ -138,29 +134,29 @@ class TestPromptMapper:
             project_id=uuid.uuid4(),
             annotations=[annotation_db_1, annotation_db_2],
         )
-
         label_to_category_id = {label_id_1: 0, label_id_2: 1}
+        label_id_to_name = {label_id_1: "car", label_id_2: "person"}
         label_shot_counts: dict[uuid.UUID, int] = {}
-
+        supported_annotation_types = {AnnotationType.POLYGON}
         result = visual_prompt_to_sample(
             prompt_db,
             frame=sample_frame,
             label_to_category_id=label_to_category_id,
+            label_id_to_name=label_id_to_name,
             label_shot_counts=label_shot_counts,
+            supported_annotation_types=supported_annotation_types,
         )
-
         assert result is not None
         assert isinstance(result, Sample)
         assert len(result.categories) == 2
-        assert str(label_id_1) in result.categories
-        assert str(label_id_2) in result.categories
+        assert "car" in result.categories
+        assert "person" in result.categories
         assert label_shot_counts[label_id_1] == 1
         assert label_shot_counts[label_id_2] == 1
 
     def test_visual_prompt_to_sample_raises_error_for_text_prompt(self, sample_frame: np.ndarray) -> None:
         prompt_id = uuid.uuid4()
         project_id = uuid.uuid4()
-
         prompt_db = SimpleNamespace(
             id=prompt_id,
             type=PromptType.TEXT,
@@ -169,22 +165,23 @@ class TestPromptMapper:
             project_id=project_id,
             annotations=[],
         )
-
         label_to_category_id: dict[uuid.UUID, int] = {}
+        label_id_to_name: dict[uuid.UUID, str] = {}
         label_shot_counts: dict[uuid.UUID, int] = {}
-
+        supported_annotation_types = {AnnotationType.POLYGON}
         with pytest.raises(ServiceError, match="Cannot convert non-visual prompt"):
             visual_prompt_to_sample(
                 prompt_db,
                 frame=sample_frame,
                 label_to_category_id=label_to_category_id,
+                label_id_to_name=label_id_to_name,
                 label_shot_counts=label_shot_counts,
+                supported_annotation_types=supported_annotation_types,
             )
 
     def test_visual_prompt_to_sample_raises_error_without_annotations(self, sample_frame: np.ndarray) -> None:
         prompt_id = uuid.uuid4()
         frame_id = uuid.uuid4()
-
         prompt_db = SimpleNamespace(
             id=prompt_id,
             type=PromptType.VISUAL,
@@ -193,103 +190,89 @@ class TestPromptMapper:
             project_id=uuid.uuid4(),
             annotations=[],
         )
-
         label_to_category_id: dict[uuid.UUID, int] = {}
+        label_id_to_name: dict[uuid.UUID, str] = {}
         label_shot_counts: dict[uuid.UUID, int] = {}
-
+        supported_annotation_types = {AnnotationType.POLYGON}
         with pytest.raises(ServiceError, match="has no valid annotations"):
             visual_prompt_to_sample(
                 prompt_db,
                 frame=sample_frame,
                 label_to_category_id=label_to_category_id,
+                label_id_to_name=label_id_to_name,
                 label_shot_counts=label_shot_counts,
+                supported_annotation_types=supported_annotation_types,
             )
 
     def test_deduplicate_annotations_removes_exact_duplicates(self) -> None:
         label_id = uuid.uuid4()
-
         config1 = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.1), Point(x=0.5, y=0.5), Point(x=0.1, y=0.5)],
+            points=[Point(x=64, y=48), Point(x=320, y=48), Point(x=320, y=240), Point(x=64, y=240)],
         )
         config2 = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.1), Point(x=0.5, y=0.5), Point(x=0.1, y=0.5)],
+            points=[Point(x=64, y=48), Point(x=320, y=48), Point(x=320, y=240), Point(x=64, y=240)],
         )
-
         annotations = [
             AnnotationSchema(config=config1, label_id=label_id),
             AnnotationSchema(config=config2, label_id=label_id),
         ]
-
         result = deduplicate_annotations(annotations, 480, 640)
-
         assert len(result) == 1
         assert result[0].label_id == label_id
 
     def test_deduplicate_annotations_removes_similar_polygons(self) -> None:
         label_id = uuid.uuid4()
-
         # Very similar polygons (should have high IoU)
         config1 = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.1), Point(x=0.5, y=0.5), Point(x=0.1, y=0.5)],
+            points=[Point(x=64, y=48), Point(x=320, y=48), Point(x=320, y=240), Point(x=64, y=240)],
         )
         config2 = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.11, y=0.11), Point(x=0.51, y=0.11), Point(x=0.51, y=0.51), Point(x=0.11, y=0.51)],
+            points=[Point(x=70, y=53), Point(x=326, y=53), Point(x=326, y=246), Point(x=70, y=246)],
         )
-
         annotations = [
             AnnotationSchema(config=config1, label_id=label_id),
             AnnotationSchema(config=config2, label_id=label_id),
         ]
-
         result = deduplicate_annotations(annotations, 480, 640, iou_threshold=0.9)
-
         assert len(result) == 1
 
     def test_deduplicate_annotations_keeps_different_polygons(self) -> None:
         label_id = uuid.uuid4()
-
-        # Different polygons (low IoU)
+        # Non-overlapping polygons in different regions (pixel coords)
         config1 = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.3, y=0.1), Point(x=0.3, y=0.3), Point(x=0.1, y=0.3)],
+            points=[Point(x=64, y=48), Point(x=192, y=48), Point(x=192, y=192), Point(x=64, y=192)],
         )
         config2 = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.6, y=0.6), Point(x=0.8, y=0.6), Point(x=0.8, y=0.8), Point(x=0.6, y=0.8)],
+            points=[Point(x=384, y=240), Point(x=512, y=240), Point(x=512, y=384), Point(x=384, y=384)],
         )
-
         annotations = [
             AnnotationSchema(config=config1, label_id=label_id),
             AnnotationSchema(config=config2, label_id=label_id),
         ]
-
         result = deduplicate_annotations(annotations, 480, 640)
-
         assert len(result) == 2
 
     def test_deduplicate_annotations_keeps_non_polygons(self) -> None:
         label_id = uuid.uuid4()
-
         polygon_config = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.1), Point(x=0.5, y=0.5), Point(x=0.1, y=0.5)],
+            points=[Point(x=64, y=48), Point(x=320, y=48), Point(x=320, y=240), Point(x=64, y=240)],
         )
         rectangle_config = RectangleAnnotation(
             type=AnnotationType.RECTANGLE,
-            points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.5)],
+            points=[Point(x=10, y=10), Point(x=50, y=50)],
         )
-
         annotations = [
             AnnotationSchema(config=polygon_config, label_id=label_id),
             AnnotationSchema(config=rectangle_config, label_id=label_id),
         ]
-
         result = deduplicate_annotations(annotations, 480, 640)
-
         assert len(result) == 2
         assert any(ann.config.type == AnnotationType.POLYGON for ann in result)
         assert any(ann.config.type == AnnotationType.RECTANGLE for ann in result)
@@ -302,11 +285,9 @@ class TestPromptMapper:
         label_id = uuid.uuid4()
         config = PolygonAnnotation(
             type=AnnotationType.POLYGON,
-            points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.1), Point(x=0.5, y=0.5), Point(x=0.1, y=0.5)],
+            points=[Point(x=64, y=48), Point(x=320, y=48), Point(x=320, y=240), Point(x=64, y=240)],
         )
         annotations = [AnnotationSchema(config=config, label_id=label_id)]
-
         result = deduplicate_annotations(annotations, 480, 640)
-
         assert len(result) == 1
         assert result[0].label_id == label_id

--- a/application/backend/tests/unit/domain/services/test_project_service.py
+++ b/application/backend/tests/unit/domain/services/test_project_service.py
@@ -70,7 +70,7 @@ def make_project(
         name=name,
         active=active,
         device="auto",
-        prompt_mode="visual",
+        prompt_mode="VISUAL",
         sources=sources,
         processors=processors,
         sinks=sinks,

--- a/application/backend/tests/unit/domain/services/test_prompt_service.py
+++ b/application/backend/tests/unit/domain/services/test_prompt_service.py
@@ -33,8 +33,8 @@ from domain.services.schemas.prompt import (
 )
 
 
-def make_project(project_id=None, name="proj"):
-    return SimpleNamespace(id=project_id or uuid.uuid4(), name=name)
+def make_project(project_id=None, name="proj", prompt_mode="visual"):
+    return SimpleNamespace(id=project_id or uuid.uuid4(), name=name, prompt_mode=prompt_mode)
 
 
 def make_text_prompt_db(prompt_id=None, project_id=None, text="test prompt"):
@@ -84,12 +84,14 @@ def service():
     project_repo = MagicMock(name="ProjectRepositoryMock")
     frame_repo = MagicMock(name="FrameRepositoryMock")
     label_repo = MagicMock(name="LabelRepositoryMock")
+    processor_repo = MagicMock(name="ProcessorRepositoryMock")
     return PromptService(
         session=session,
         prompt_repository=prompt_repo,
         project_repository=project_repo,
         frame_repository=frame_repo,
         label_repository=label_repo,
+        processor_repository=processor_repo,
     )
 
 
@@ -159,10 +161,11 @@ def polygon_annotation(label_id):
 
 
 def test_list_prompts_success(service, mock_project, project_id, test_image):
-    text_prompt = make_text_prompt_db(project_id=project_id)
+    # list_prompts routes by prompt_mode; mock_project has prompt_mode="visual"
     visual_prompt = make_visual_prompt_db(project_id=project_id)
-    service.prompt_repository.list_with_pagination_by_project.return_value = ([text_prompt, visual_prompt], 2)
-    service.frame_repository.read_frame.return_value = test_image
+    visual_prompt2 = make_visual_prompt_db(project_id=project_id)
+    service.prompt_repository.list_all_by_project.return_value = [visual_prompt, visual_prompt2]
+    service.processor_repository.get_active_in_project.return_value = None
 
     result = service.list_prompts(project_id, offset=0, limit=10)
 
@@ -171,13 +174,12 @@ def test_list_prompts_success(service, mock_project, project_id, test_image):
     assert result.pagination.count == 2
     assert result.pagination.offset == 0
     assert result.pagination.limit == 10
-    service.prompt_repository.list_with_pagination_by_project.assert_called_once_with(
-        project_id=project_id, offset=0, limit=10
-    )
+    service.prompt_repository.list_all_by_project.assert_called_once()
 
 
 def test_list_prompts_empty(service, mock_project, project_id):
-    service.prompt_repository.list_with_pagination_by_project.return_value = ([], 0)
+    service.prompt_repository.list_all_by_project.return_value = []
+    service.processor_repository.get_active_in_project.return_value = None
 
     result = service.list_prompts(project_id)
 
@@ -558,57 +560,6 @@ def test_project_not_found(service):
         service.list_prompts(uuid.uuid4())
 
     assert exc_info.value.resource_type == ResourceType.PROJECT
-
-
-def test_normalization_scales_visual_points(service, frame_id, label_id):
-    create_schema = VisualPromptCreateSchema(
-        id=uuid.uuid4(),
-        type=PromptType.VISUAL,
-        frame_id=frame_id,
-        annotations=[
-            AnnotationSchema(
-                config=RectangleAnnotation(
-                    type=AnnotationType.RECTANGLE,
-                    points=[Point(x=10.0, y=20.0), Point(x=60.0, y=120.0)],
-                ),
-                label_id=label_id,
-            )
-        ],
-    )
-
-    normalized = service._normalization(create_schema, height=200, width=100)
-
-    assert normalized.annotations[0].config.points[0].x == pytest.approx(0.1)
-    assert normalized.annotations[0].config.points[0].y == pytest.approx(0.1)
-    assert normalized.annotations[0].config.points[1].x == pytest.approx(0.6)
-    assert normalized.annotations[0].config.points[1].y == pytest.approx(0.6)
-
-
-def test_denormalization_scales_visual_points(service, project_id, frame_id):
-    annotation = make_annotation_db()
-    annotation.config = {
-        "type": AnnotationType.RECTANGLE,
-        "points": [{"x": 0.25, "y": 0.5}, {"x": 0.75, "y": 0.9}],
-    }
-    prompt = make_visual_prompt_db(project_id=project_id, frame_id=frame_id, annotations=[annotation])
-    service.frame_repository.read_frame.return_value = np.zeros((100, 200, 3), dtype=np.uint8)
-
-    denormalized = service._denormalization(project_id=project_id, data=prompt)
-
-    points = denormalized.annotations[0].config["points"]
-    assert points[0]["x"] == 50
-    assert points[0]["y"] == 50
-    assert points[1]["x"] == 150
-    assert points[1]["y"] == 90
-    service.frame_repository.read_frame.assert_called_once_with(project_id=project_id, frame_id=frame_id)
-
-
-def test_denormalization_raises_when_frame_missing(service, project_id, frame_id):
-    prompt = make_visual_prompt_db(project_id=project_id, frame_id=frame_id, annotations=[make_annotation_db()])
-    service.frame_repository.read_frame.return_value = None
-
-    with pytest.raises(ResourceNotFoundError):
-        service._denormalization(project_id=project_id, data=prompt)
 
 
 def test_create_visual_prompt_with_multiple_similar_annotations_deduplicates(

--- a/application/backend/tests/unit/domain/services/test_prompt_service.py
+++ b/application/backend/tests/unit/domain/services/test_prompt_service.py
@@ -33,7 +33,7 @@ from domain.services.schemas.prompt import (
 )
 
 
-def make_project(project_id=None, name="proj", prompt_mode="visual"):
+def make_project(project_id=None, name="proj", prompt_mode="VISUAL"):
     return SimpleNamespace(id=project_id or uuid.uuid4(), name=name, prompt_mode=prompt_mode)
 
 
@@ -161,10 +161,10 @@ def polygon_annotation(label_id):
 
 
 def test_list_prompts_success(service, mock_project, project_id, test_image):
-    # list_prompts routes by prompt_mode; mock_project has prompt_mode="visual"
+    # list_prompts routes by prompt_mode; mock_project has prompt_mode="VISUAL"
     visual_prompt = make_visual_prompt_db(project_id=project_id)
     visual_prompt2 = make_visual_prompt_db(project_id=project_id)
-    service.prompt_repository.list_all_by_project.return_value = [visual_prompt, visual_prompt2]
+    service.prompt_repository.list_by_project_and_type.return_value = [visual_prompt, visual_prompt2]
     service.processor_repository.get_active_in_project.return_value = None
 
     result = service.list_prompts(project_id, offset=0, limit=10)
@@ -174,11 +174,11 @@ def test_list_prompts_success(service, mock_project, project_id, test_image):
     assert result.pagination.count == 2
     assert result.pagination.offset == 0
     assert result.pagination.limit == 10
-    service.prompt_repository.list_all_by_project.assert_called_once()
+    service.prompt_repository.list_by_project_and_type.assert_called_once()
 
 
 def test_list_prompts_empty(service, mock_project, project_id):
-    service.prompt_repository.list_all_by_project.return_value = []
+    service.prompt_repository.list_by_project_and_type.return_value = []
     service.processor_repository.get_active_in_project.return_value = None
 
     result = service.list_prompts(project_id)

--- a/application/backend/tests/unit/domain/services/test_thumbnails.py
+++ b/application/backend/tests/unit/domain/services/test_thumbnails.py
@@ -138,7 +138,7 @@ class TestDrawRectangle:
         rect = RectangleAnnotation(type=AnnotationType.RECTANGLE, points=[Point(x=0.2, y=0.2), Point(x=0.8, y=0.8)])
         color = (0, 0, 255)
 
-        result = _draw_filled_rectangle(overlay, rect, color, image_width=200, image_height=200, border_thickness=2)
+        result = _draw_filled_rectangle(overlay, rect, color, scale_x=200, scale_y=200, border_thickness=2)
 
         center_pixel = result[100, 100]
         np.testing.assert_array_equal(center_pixel, color)
@@ -148,7 +148,7 @@ class TestDrawRectangle:
         rect = RectangleAnnotation(type=AnnotationType.RECTANGLE, points=[Point(x=0.1, y=0.1), Point(x=0.5, y=0.5)])
         color = (255, 0, 0)
 
-        result = _draw_filled_rectangle(overlay, rect, color, image_width=100, image_height=100, border_thickness=1)
+        result = _draw_filled_rectangle(overlay, rect, color, scale_x=100, scale_y=100, border_thickness=1)
 
         assert np.any(result[10, 10] == color)
         assert np.any(result[50, 50] == color)
@@ -158,7 +158,7 @@ class TestDrawRectangle:
         rect = RectangleAnnotation(type=AnnotationType.RECTANGLE, points=[Point(x=0.2, y=0.2), Point(x=0.6, y=0.6)])
         color = (0, 255, 0)
 
-        result = _draw_filled_rectangle(original, rect, color, image_width=100, image_height=100, border_thickness=2)
+        result = _draw_filled_rectangle(original, rect, color, scale_x=100, scale_y=100, border_thickness=2)
 
         assert result is original
         assert np.any(result[40, 40] == color)
@@ -172,7 +172,7 @@ class TestDrawPolygon:
         )
         color = (0, 255, 0)
 
-        result = _draw_filled_polygon(overlay, polygon, color, image_width=200, image_height=200, border_thickness=2)
+        result = _draw_filled_polygon(overlay, polygon, color, scale_x=200, scale_y=200, border_thickness=2)
 
         center_pixel = result[120, 100]
         np.testing.assert_array_equal(center_pixel, color)
@@ -185,7 +185,7 @@ class TestDrawPolygon:
         )
         color = (0, 0, 255)
 
-        result = _draw_filled_polygon(overlay, polygon, color, image_width=100, image_height=100, border_thickness=1)
+        result = _draw_filled_polygon(overlay, polygon, color, scale_x=100, scale_y=100, border_thickness=1)
 
         assert np.any(result[50, 50] == color)
 
@@ -197,7 +197,7 @@ class TestDrawPolygon:
         )
         color = (128, 128, 128)
 
-        result = _draw_filled_polygon(original, polygon, color, image_width=100, image_height=100, border_thickness=1)
+        result = _draw_filled_polygon(original, polygon, color, scale_x=100, scale_y=100, border_thickness=1)
 
         assert result is original
 
@@ -314,9 +314,7 @@ class TestGenerateThumbnail:
         frame = create_test_frame(width=400, height=400, color=(100, 100, 100))
         label_id = uuid4()
         annotation = AnnotationSchema(
-            config=RectangleAnnotation(
-                type=AnnotationType.RECTANGLE, points=[Point(x=0.0, y=0.0), Point(x=1.0, y=1.0)]
-            ),
+            config=RectangleAnnotation(type=AnnotationType.RECTANGLE, points=[Point(x=0, y=0), Point(x=400, y=400)]),
             label_id=label_id,
         )
         label = make_label(color="#FF0000")
@@ -327,6 +325,7 @@ class TestGenerateThumbnail:
         decoded_bytes = base64.b64decode(b64_data)
         decoded_img = cv2.imdecode(np.frombuffer(decoded_bytes, np.uint8), cv2.IMREAD_COLOR)
 
-        center_pixel = decoded_img[200, 200]
+        center_h, center_w = decoded_img.shape[0] // 2, decoded_img.shape[1] // 2
+        center_pixel = decoded_img[center_h, center_w]
         assert not np.array_equal(center_pixel, [0, 0, 255])
         assert not np.array_equal(center_pixel, [100, 100, 100])

--- a/application/backend/tests/unit/runtime/core/components/factories/test_model.py
+++ b/application/backend/tests/unit/runtime/core/components/factories/test_model.py
@@ -7,9 +7,8 @@ from uuid import uuid4
 import pytest
 from instantlearn.utils.constants import SAMModelName
 
-from domain.services.schemas.processor import MatcherConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from domain.services.schemas.device import AvailableDeviceSchema, Device
-from domain.services.schemas.processor import MatcherConfig, PerDinoConfig, SoftMatcherConfig
+from domain.services.schemas.processor import MatcherConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from runtime.core.components.factories.model import DeviceResolver, ModelFactory
 from runtime.core.components.models.passthrough_model import PassThroughModelHandler
 
@@ -306,12 +305,13 @@ class TestModelFactory:
 
             model_factory.create(mock_reference_batch, config)
 
-            mock_sam3.assert_called_once_with(
-                confidence_threshold=0.5,
-                resolution=1008,
-                precision="fp32",
-                device="cpu",
-            )
+            # Verify config fields; prompt_mode is derived from reference_batch contents
+            call_kwargs = mock_sam3.call_args.kwargs
+            assert call_kwargs["confidence_threshold"] == 0.5
+            assert call_kwargs["resolution"] == 1008
+            assert call_kwargs["precision"] == "fp32"
+            assert call_kwargs["device"] == "cpu"
+            assert "prompt_mode" in call_kwargs
             mock_handler.assert_called_once_with(mock_model_instance, mock_reference_batch)
 
     def test_factory_returns_passthrough_for_none_reference_batch(self, model_factory):

--- a/application/backend/tests/unit/runtime/core/components/factories/test_model.py
+++ b/application/backend/tests/unit/runtime/core/components/factories/test_model.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from instantlearn.utils.constants import SAMModelName
 
+from domain.services.schemas.processor import MatcherConfig, PerDinoConfig, Sam3Config, SoftMatcherConfig
 from domain.services.schemas.device import AvailableDeviceSchema, Device
 from domain.services.schemas.processor import MatcherConfig, PerDinoConfig, SoftMatcherConfig
 from runtime.core.components.factories.model import DeviceResolver, ModelFactory
@@ -279,6 +280,36 @@ class TestModelFactory:
                 softmatching_score_threshold=0.5,
                 softmatching_bidirectional=True,
                 precision="bf16",
+                device="cpu",
+            )
+            mock_handler.assert_called_once_with(mock_model_instance, mock_reference_batch)
+
+    def test_factory_creates_sam3_model_with_config(self, mock_reference_batch, mock_settings, model_factory):
+        config = Sam3Config(
+            confidence_threshold=0.5,
+            resolution=1008,
+            precision="fp32",
+        )
+
+        with patch.multiple(
+            "runtime.core.components.factories.model",
+            get_settings=DEFAULT,
+            SAM3=DEFAULT,
+            TorchModelHandler=DEFAULT,
+        ) as mocks:
+            mocks["get_settings"].return_value = mock_settings
+            mock_sam3 = mocks["SAM3"]
+            mock_handler = mocks["TorchModelHandler"]
+
+            mock_model_instance = MagicMock()
+            mock_sam3.return_value = mock_model_instance
+
+            model_factory.create(mock_reference_batch, config)
+
+            mock_sam3.assert_called_once_with(
+                confidence_threshold=0.5,
+                resolution=1008,
+                precision="fp32",
                 device="cpu",
             )
             mock_handler.assert_called_once_with(mock_model_instance, mock_reference_batch)

--- a/application/backend/tests/unit/runtime/test_components.py
+++ b/application/backend/tests/unit/runtime/test_components.py
@@ -42,13 +42,10 @@ def test_create_processor_passes_pipeline_device_to_model_factory():
     )
 
     with (
-        patch("runtime.components.ProjectService") as svc_cls,
         patch("runtime.components.get_settings", return_value=settings),
         patch("runtime.components.Processor") as processor_cls,
     ):
-        svc_cls.return_value.get_pipeline_config.return_value = cfg
-
-        factory.create_processor(project_id, reference_batch)
+        factory.create_processor(cfg, reference_batch)
 
         factory._model_factory.create.assert_called_once_with(
             reference_batch=reference_batch,

--- a/application/backend/tests/unit/runtime/test_pipeline_manager.py
+++ b/application/backend/tests/unit/runtime/test_pipeline_manager.py
@@ -343,7 +343,7 @@ class TestPipelineManager:
         project_id = uuid4()
 
         with patch("runtime.pipeline_manager.PromptRepository") as prompt_repo_cls:
-            prompt_repo_cls.return_value.list_all_by_project.return_value = []
+            prompt_repo_cls.return_value.list_by_project_and_type.return_value = []
             result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
 
         assert result is None
@@ -379,7 +379,7 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.visual_prompt_to_sample", return_value=fake_sample),
             patch("runtime.pipeline_manager.Batch.collate", return_value=fake_batch),
         ):
-            prompt_repo_cls.return_value.list_all_by_project.return_value = [visual_prompt]
+            prompt_repo_cls.return_value.list_by_project_and_type.return_value = [visual_prompt]
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
                 label_to_category_id={label_id: 0},
                 category_id_to_label_id={0: str(label_id)},
@@ -392,7 +392,7 @@ class TestPipelineManager:
         assert batch is fake_batch
         assert category_id_to_label_id == {0: str(label_id)}
 
-        prompt_repo_cls.return_value.list_all_by_project.assert_called_once_with(
+        prompt_repo_cls.return_value.list_by_project_and_type.assert_called_once_with(
             project_id=project_id, prompt_type=PromptType.VISUAL
         )
         read_frame.assert_called_once_with(project_id, frame_id)
@@ -422,7 +422,7 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.visual_prompt_to_sample", return_value=fake_sample),
             patch("runtime.pipeline_manager.Batch.collate", return_value=fake_batch),
         ):
-            prompt_repo_cls.return_value.list_all_by_project.return_value = [visual_prompt]
+            prompt_repo_cls.return_value.list_by_project_and_type.return_value = [visual_prompt]
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
                 label_to_category_id={label_id_a: 0, label_id_b: 1},
                 category_id_to_label_id={0: str(label_id_a), 1: str(label_id_b)},
@@ -442,7 +442,7 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.PromptRepository") as prompt_repo_cls,
             patch("runtime.pipeline_manager.LabelService"),
         ):
-            prompt_repo_cls.return_value.list_all_by_project.return_value = []
+            prompt_repo_cls.return_value.list_by_project_and_type.return_value = []
 
             result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
 
@@ -460,7 +460,7 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.LabelService") as label_svc_cls,
             patch.object(mgr._frame_repository, "read_frame", return_value=None),
         ):
-            prompt_repo_cls.return_value.list_all_by_project.return_value = [visual_prompt]
+            prompt_repo_cls.return_value.list_by_project_and_type.return_value = [visual_prompt]
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
                 label_to_category_id={}, category_id_to_label_id={}
             )
@@ -487,7 +487,7 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.cv2.cvtColor", return_value=np.zeros((64, 64, 3), dtype=np.uint8)),
             patch("runtime.pipeline_manager.visual_prompt_to_sample", side_effect=Exception("Mapper error")),
         ):
-            prompt_repo_cls.return_value.list_all_by_project.return_value = [visual_prompt]
+            prompt_repo_cls.return_value.list_by_project_and_type.return_value = [visual_prompt]
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
                 label_to_category_id={}, category_id_to_label_id={}
             )

--- a/application/backend/tests/unit/runtime/test_pipeline_manager.py
+++ b/application/backend/tests/unit/runtime/test_pipeline_manager.py
@@ -17,6 +17,7 @@ from domain.dispatcher import (
     ProjectActivationEvent,
     ProjectDeactivationEvent,
 )
+from domain.services.schemas.annotation import AnnotationType
 from domain.services.schemas.pipeline import PipelineConfig
 from runtime.errors import PipelineNotActiveError, PipelineProjectMismatchError
 from runtime.pipeline_manager import PipelineManager
@@ -84,11 +85,12 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.Pipeline") as pipeline_cls,
             patch("runtime.pipeline_manager.FrameBroadcaster"),
             patch("runtime.pipeline_manager.FrameRepository") as repo_cls,
-            patch.object(PipelineManager, "get_reference_batch", return_value=None),
+            patch.object(PipelineManager, "_build_reference_batch", return_value=None),
             patch.object(PipelineManager, "_refresh_visualization_info", return_value=None),
         ):
             svc_inst = svc_cls.return_value
             svc_inst.get_active_pipeline_config.return_value = pipeline_cfg
+            svc_inst.get_pipeline_config.return_value = pipeline_cfg
             repo_inst = repo_cls.return_value
 
             # Configure the mock Pipeline to support method chaining
@@ -101,9 +103,9 @@ class TestPipelineManager:
             mgr.start()
 
             svc_inst.get_active_pipeline_config.assert_called_once()
-            mock_component_factory.create_source.assert_called_once_with(pipeline_cfg.project_id)
-            mock_component_factory.create_processor.assert_called_once_with(pipeline_cfg.project_id, None)
-            mock_component_factory.create_sink.assert_called_once_with(pipeline_cfg.project_id)
+            mock_component_factory.create_source.assert_called_once_with(pipeline_cfg.reader)
+            mock_component_factory.create_processor.assert_called_once_with(pipeline_cfg, None)
+            mock_component_factory.create_sink.assert_called_once_with(pipeline_cfg.writer)
 
             # Pipeline is called with project_id and two FrameBroadcasters
             pipeline_cls.assert_called_once()
@@ -142,10 +144,13 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.Pipeline") as pipeline_cls,
             patch("runtime.pipeline_manager.FrameBroadcaster"),
             patch("runtime.pipeline_manager.FrameRepository") as repo_cls,
-            patch.object(PipelineManager, "get_reference_batch", return_value=None),
+            patch("runtime.pipeline_manager.ProjectService") as svc_cls_act,
+            patch.object(PipelineManager, "_build_reference_batch", return_value=None),
             patch.object(PipelineManager, "_refresh_visualization_info", return_value=None),
         ):
             pid = uuid4()
+            pipeline_cfg_act = PipelineConfig(project_id=pid, reader=None, processor=None, writer=None)
+            svc_cls_act.return_value.get_pipeline_config.return_value = pipeline_cfg_act
             repo_inst = repo_cls.return_value
 
             # Configure the mock Pipeline to support method chaining
@@ -158,9 +163,9 @@ class TestPipelineManager:
             ev = ProjectActivationEvent(project_id=pid)
             mgr.on_config_change(ev)
 
-            mock_component_factory.create_source.assert_called_once_with(pid)
-            mock_component_factory.create_processor.assert_called_once_with(pid, None)
-            mock_component_factory.create_sink.assert_called_once_with(pid)
+            mock_component_factory.create_source.assert_called_once_with(pipeline_cfg_act.reader)
+            mock_component_factory.create_processor.assert_called_once_with(pipeline_cfg_act, None)
+            mock_component_factory.create_sink.assert_called_once_with(pipeline_cfg_act.writer)
 
             # Pipeline is called with project_id and two FrameBroadcasters
             pipeline_cls.assert_called_once()
@@ -182,12 +187,15 @@ class TestPipelineManager:
             patch("runtime.pipeline_manager.Pipeline") as pipeline_cls,
             patch("runtime.pipeline_manager.FrameBroadcaster"),
             patch("runtime.pipeline_manager.FrameRepository"),
-            patch.object(PipelineManager, "get_reference_batch", return_value=None),
+            patch("runtime.pipeline_manager.ProjectService") as svc_cls_rep,
+            patch.object(PipelineManager, "_build_reference_batch", return_value=None),
             patch.object(PipelineManager, "_refresh_visualization_info", return_value=None),
         ):
             # Existing pipeline
             old_pipeline = Mock()
             pid_new = uuid4()
+            pipeline_cfg_rep = PipelineConfig(project_id=pid_new, reader=None, processor=None, writer=None)
+            svc_cls_rep.return_value.get_pipeline_config.return_value = pipeline_cfg_rep
 
             # Configure the mock Pipeline to support method chaining
             pipeline_inst = pipeline_cls.return_value
@@ -202,9 +210,9 @@ class TestPipelineManager:
             mgr.on_config_change(ev)
 
             old_pipeline.stop.assert_called_once()
-            mock_component_factory.create_source.assert_called_once_with(pid_new)
-            mock_component_factory.create_processor.assert_called_once_with(pid_new, None)
-            mock_component_factory.create_sink.assert_called_once_with(pid_new)
+            mock_component_factory.create_source.assert_called_once_with(pipeline_cfg_rep.reader)
+            mock_component_factory.create_processor.assert_called_once_with(pipeline_cfg_rep, None)
+            mock_component_factory.create_sink.assert_called_once_with(pipeline_cfg_rep.writer)
 
             # Pipeline is called with project_id and two FrameBroadcasters
             pipeline_cls.assert_called_once()
@@ -274,11 +282,16 @@ class TestPipelineManager:
     def test_on_component_update_applies_config_for_matching_project(
         self, dispatcher, session_factory, mock_component_factory
     ):
-        with patch("runtime.pipeline_manager.Pipeline"):
+        with (
+            patch("runtime.pipeline_manager.Pipeline"),
+            patch("runtime.pipeline_manager.ProjectService") as svc_cls_comp,
+        ):
             pid = uuid4()
             component_id = uuid4()
             running = Mock()
             running.project_id = pid
+            pipeline_cfg_comp = PipelineConfig(project_id=pid, reader=None, processor=None, writer=None)
+            svc_cls_comp.return_value.get_pipeline_config.return_value = pipeline_cfg_comp
 
             mgr = PipelineManager(dispatcher, session_factory, component_factory=mock_component_factory)
             mgr._pipeline = running
@@ -288,7 +301,7 @@ class TestPipelineManager:
             )
             mgr.on_config_change(ev)
 
-            mock_component_factory.create_source.assert_called_once_with(pid)
+            mock_component_factory.create_source.assert_called_once_with(pipeline_cfg_comp.reader)
             running.set_source.assert_called_once()
 
     def test_on_component_update_ignores_mismatch(self, dispatcher, session_factory):
@@ -325,9 +338,15 @@ class TestPipelineManager:
         mgr.stop()
         assert mgr._pipeline is None
 
-    def test_get_reference_batch_text_prompts_returns_none(self, dispatcher, session_factory) -> None:
+    def test_get_visual_reference_batch_no_prompts_returns_none(self, dispatcher, session_factory) -> None:
         mgr = PipelineManager(dispatcher, session_factory)
-        assert mgr.get_reference_batch(uuid4(), PromptType.TEXT) is None
+        project_id = uuid4()
+
+        with patch("runtime.pipeline_manager.PromptRepository") as prompt_repo_cls:
+            prompt_repo_cls.return_value.list_all_by_project.return_value = []
+            result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
+
+        assert result is None
 
     def test_get_reference_batch_for_visual_prompts_returns_batch_and_mapping(
         self, dispatcher, session_factory
@@ -366,7 +385,7 @@ class TestPipelineManager:
                 category_id_to_label_id={0: str(label_id)},
             )
 
-            result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
+            result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
 
         assert result is not None
         batch, category_id_to_label_id = result
@@ -409,7 +428,7 @@ class TestPipelineManager:
                 category_id_to_label_id={0: str(label_id_a), 1: str(label_id_b)},
             )
 
-            result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
+            result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
 
         assert result is not None
         _, category_id_to_label_id = result
@@ -425,7 +444,7 @@ class TestPipelineManager:
         ):
             prompt_repo_cls.return_value.list_all_by_project.return_value = []
 
-            result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
+            result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
 
         assert result is None
 
@@ -446,7 +465,7 @@ class TestPipelineManager:
                 label_to_category_id={}, category_id_to_label_id={}
             )
 
-            result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
+            result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
 
         assert result is None
 
@@ -473,6 +492,6 @@ class TestPipelineManager:
                 label_to_category_id={}, category_id_to_label_id={}
             )
 
-            result = mgr.get_reference_batch(project_id, PromptType.VISUAL)
+            result = mgr.get_visual_reference_batch(project_id, {AnnotationType.POLYGON})
 
         assert result is None

--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -256,7 +256,6 @@
             "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -923,7 +922,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -947,7 +945,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -4503,7 +4500,6 @@
             "resolved": "https://registry.npmjs.org/@react-spectrum/provider/-/provider-3.10.8.tgz",
             "integrity": "sha512-Cr8A0cy2TB4bSVNne9sfUcFYzsp4RikNRHhEyiIF6s6QFMtp0SEFRIX3eW8fP+8vfIHhEC23MvNFK2PPkcabUg==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@react-aria/i18n": "^3.12.11",
                 "@react-aria/overlays": "^3.28.0",
@@ -6387,7 +6383,6 @@
             "integrity": "sha512-KoSTtKjzQUQwamcbeCp63Ne9kL7io1WI4+skTJe2chfLz6wsp/Gfg8aKkfs1DuyG1p+zxFDcYpwTWMsNtxqqiw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rspack/core": "1.4.11",
                 "@rspack/lite-tapable": "~1.0.1",
@@ -6981,7 +6976,6 @@
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -7114,7 +7108,6 @@
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.87.0.tgz",
             "integrity": "sha512-3uRCGHo7KWHl6h7ptzLd5CbrjTQP5Q/37aC1cueClkSN4t/OaNFmfGolgs1AoA0kFjP/OZxTY2ytQoifyJzpWQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tanstack/query-core": "5.87.0"
             },
@@ -7368,7 +7361,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -7669,7 +7661,6 @@
             "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -7680,7 +7671,6 @@
             "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.0.0"
             }
@@ -7744,7 +7734,6 @@
             "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.39.1",
                 "@typescript-eslint/types": "8.39.1",
@@ -8418,7 +8407,6 @@
             "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/utils": "3.2.4",
                 "fflate": "^0.8.2",
@@ -8469,7 +8457,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8877,7 +8864,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001733",
                 "electron-to-chromium": "^1.5.199",
@@ -10201,7 +10187,6 @@
             "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -12090,7 +12075,6 @@
             "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.2.1",
                 "data-urls": "^5.0.0",
@@ -12511,7 +12495,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bundled-es-modules/cookie": "^2.0.1",
                 "@bundled-es-modules/statuses": "^1.0.1",
@@ -12869,7 +12852,6 @@
             "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.0.tgz",
             "integrity": "sha512-PshIdm1NgdLvb05zp8LqRQMNSKzIlPkyMxYFxwyHR+UlKD4t2nUjkDhNxeRbhRSEd3x5EUNh2w5sJYwkhOH4fg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "openapi-typescript-helpers": "^0.0.15"
             }
@@ -13257,7 +13239,6 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -13387,7 +13368,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
             "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13501,7 +13481,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
             "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.26.0"
             },
@@ -13526,15 +13505,13 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/react-redux": {
             "version": "9.2.0",
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -13559,7 +13536,6 @@
             "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13729,8 +13705,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -13876,7 +13851,6 @@
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -15197,7 +15171,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15506,7 +15479,6 @@
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -15571,7 +15543,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },
@@ -15744,7 +15715,6 @@
             "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -15911,7 +15881,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15925,7 +15894,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -16461,7 +16429,6 @@
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/application/ui/playwright.config.ts
+++ b/application/ui/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : 3,
+    workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [[CI ? 'github' : 'list'], ['html', { open: 'never' }]],
     use: {

--- a/application/ui/playwright.config.ts
+++ b/application/ui/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : undefined,
+    workers: process.env.CI ? 1 : 3,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [[CI ? 'github' : 'list'], ['html', { open: 'never' }]],
     use: {

--- a/application/ui/src/api/index.ts
+++ b/application/ui/src/api/index.ts
@@ -31,14 +31,19 @@ type SinkWithoutConfig = Omit<SinkConfig, 'config'>;
 export type MQTTConfig = components['schemas']['MqttConfig'];
 export type MQTTSinkType = SinkWithoutConfig & { config: MQTTConfig };
 
+export type { SchemaSupportedModelMetadataSchema as SupportedModelMetadataType } from './openapi-spec';
+export type { SchemaSupportedPromptType as SupportedPromptType } from './openapi-spec';
+
 type MatcherConfig = components['schemas']['MatcherConfig'];
 type PerDINOConfig = components['schemas']['PerDinoConfig'];
 type SoftMatcherConfig = components['schemas']['SoftMatcherConfig'];
+type Sam3Config = components['schemas']['Sam3Config'];
 
 export type ModelType = components['schemas']['ProcessorSchema'];
 export type MatcherModel = Omit<ModelType, 'config'> & { config: MatcherConfig };
 export type PerDINOModel = Omit<ModelType, 'config'> & { config: PerDINOConfig };
 export type SoftMatcherModel = Omit<ModelType, 'config'> & { config: SoftMatcherConfig };
+export type Sam3Model = Omit<ModelType, 'config'> & { config: Sam3Config };
 
 export { $api, client } from './client';
 export {

--- a/application/ui/src/components/sidebar/sidebar.component.test.tsx
+++ b/application/ui/src/components/sidebar/sidebar.component.test.tsx
@@ -29,7 +29,7 @@ describe('Sidebar', () => {
     it('renders sidebar with prompt tab', async () => {
         renderSidebar();
 
-        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i }, { timeout: 5000 });
+        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i });
         expect(promptButton).toBeInTheDocument();
         expect(promptButton).toBeEnabled();
     });
@@ -37,7 +37,7 @@ describe('Sidebar', () => {
     it('expands sidebar content when tab is toggled', async () => {
         renderSidebar();
 
-        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i }, { timeout: 5000 });
+        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i });
 
         expect(promptButton).toHaveAttribute('aria-pressed', 'true');
         expect(await screen.findByRole('heading', { name: /prompt/i })).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('Sidebar', () => {
     it('collapses sidebar when same tab is clicked again', async () => {
         renderSidebar();
 
-        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i }, { timeout: 5000 });
+        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i });
 
         expect(promptButton).toHaveAttribute('aria-pressed', 'true');
         expect(await screen.findByRole('heading', { name: /prompt/i })).toBeInTheDocument();

--- a/application/ui/src/components/sidebar/sidebar.component.test.tsx
+++ b/application/ui/src/components/sidebar/sidebar.component.test.tsx
@@ -7,8 +7,13 @@ import { render } from '@/test-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { Group } from 'react-resizable-panels';
 import { SelectedFrameProvider } from 'src/shared/selected-frame-provider.component';
+import { vi } from 'vitest';
 
 import { Sidebar } from './sidebar.component';
+
+vi.mock('../../features/prompts/prompt.component', () => ({
+    Prompt: () => <h2>Prompt</h2>,
+}));
 
 const renderSidebar = () => {
     return render(
@@ -24,7 +29,7 @@ describe('Sidebar', () => {
     it('renders sidebar with prompt tab', async () => {
         renderSidebar();
 
-        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i });
+        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i }, { timeout: 5000 });
         expect(promptButton).toBeInTheDocument();
         expect(promptButton).toBeEnabled();
     });
@@ -32,7 +37,7 @@ describe('Sidebar', () => {
     it('expands sidebar content when tab is toggled', async () => {
         renderSidebar();
 
-        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i });
+        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i }, { timeout: 5000 });
 
         expect(promptButton).toHaveAttribute('aria-pressed', 'true');
         expect(await screen.findByRole('heading', { name: /prompt/i })).toBeInTheDocument();
@@ -48,7 +53,7 @@ describe('Sidebar', () => {
     it('collapses sidebar when same tab is clicked again', async () => {
         renderSidebar();
 
-        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i });
+        const promptButton = await screen.findByRole('button', { name: /toggle prompt tab/i }, { timeout: 5000 });
 
         expect(promptButton).toHaveAttribute('aria-pressed', 'true');
         expect(await screen.findByRole('heading', { name: /prompt/i })).toBeInTheDocument();

--- a/application/ui/src/features/annotator/tools/tool-manager.component.tsx
+++ b/application/ui/src/features/annotator/tools/tool-manager.component.tsx
@@ -6,14 +6,22 @@
 import { ModelType } from '@/api';
 
 import { useGetModels } from '../../prompts/models/api/use-get-models';
-import { getAnnotationTypeForModel } from '../../prompts/models/utils';
+import { useSupportedPromptTypesMap } from '../../prompts/models/use-supported-prompt-types';
+import { getAnnotationTypeFromPromptTypes } from '../../prompts/models/utils';
 import { BoundingBoxTool } from './boundingbox-tool/boundigbox-tool.component';
 import { SegmentAnythingTool } from './segment-anything-tool/segment-anything-tool.component';
 
 export const ToolManager = () => {
     const models = useGetModels();
+    const promptTypesMap = useSupportedPromptTypesMap();
     const activeModel = models.find((m: ModelType) => m.active) ?? models[0];
-    const annotationType = getAnnotationTypeForModel(activeModel);
+
+    if (!activeModel) {
+        return null;
+    }
+
+    const supportedTypes = promptTypesMap.get(activeModel.config.model_type) ?? [];
+    const annotationType = getAnnotationTypeFromPromptTypes(supportedTypes);
 
     return annotationType === 'rectangle' ? <BoundingBoxTool /> : <SegmentAnythingTool />;
 };

--- a/application/ui/src/features/project/api/use-create-project.hook.ts
+++ b/application/ui/src/features/project/api/use-create-project.hook.ts
@@ -33,7 +33,7 @@ export const useCreateProject = () => {
                     id: projectId,
                     name,
                     device: 'auto',
-                    prompt_mode: 'visual',
+                    prompt_mode: 'VISUAL',
                 },
             },
             {

--- a/application/ui/src/features/project/projects-list-entry/welcome.component.tsx
+++ b/application/ui/src/features/project/projects-list-entry/welcome.component.tsx
@@ -26,7 +26,7 @@ const useCreateProject = () => {
                     id: projectId,
                     name: projectName,
                     device: 'auto',
-                    prompt_mode: 'visual',
+                    prompt_mode: 'VISUAL',
                 },
             },
             {

--- a/application/ui/src/features/prompts/models/api/use-get-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-models.ts
@@ -4,8 +4,8 @@
  */
 
 import { useEffect, useRef } from 'react';
-
-import { $api, MatcherModel, ModelListType, PerDINOModel, SoftMatcherModel } from '@/api';
+import { useGetSupportedModels, type SupportedModelMetadata } from './use-get-supported-models';
+import { $api, MatcherModel, ModelListType, ModelType, PerDINOModel, SoftMatcherModel } from '@/api';
 import { useProjectIdentifier } from '@/hooks';
 import { v4 as uuid } from 'uuid';
 
@@ -24,80 +24,114 @@ const useGetModelsQuery = (): ModelListType => {
     return data;
 };
 
-const getDefaultMatcherModel = (id: string): MatcherModel => {
-    return {
-        id,
-        config: {
-            confidence_threshold: 0.38,
-            model_type: 'matcher',
-            num_background_points: 2,
-            num_foreground_points: 40,
-            precision: 'bf16',
-            sam_model: 'SAM-HQ-tiny',
-            encoder_model: 'dinov3_small',
-            use_mask_refinement: false,
-        },
-        active: false,
-        name: `Matcher`,
-    };
+
+const MODEL_TYPE_DISPLAY_NAMES: Record<string, string> = {
+    matcher: 'Matcher',
+    perdino: 'PerDINO',
+    soft_matcher: 'SoftMatcher',
+    sam3: 'SAM3',
 };
 
-const getDefaultPerDINOModel = (id: string): PerDINOModel => {
-    return {
-        id,
-        config: {
-            model_type: 'perdino',
-            encoder_model: 'dinov3_small',
-            sam_model: 'SAM-HQ-tiny',
-            num_foreground_points: 90,
-            num_background_points: 2,
-            num_grid_cells: 16,
-            point_selection_threshold: 0.65,
-            confidence_threshold: 0.42,
-            precision: 'bf16',
-        },
-        active: true,
-        name: 'PerDINO',
-    };
-};
-
-const getDefaultSoftMatcherModel = (id: string): SoftMatcherModel => {
-    return {
-        id,
-        config: {
-            model_type: 'soft_matcher',
-            sam_model: 'SAM-HQ-tiny',
-            encoder_model: 'dinov3_small',
-            num_foreground_points: 40,
-            num_background_points: 2,
-            confidence_threshold: 0.42,
-            use_sampling: false,
-            use_spatial_sampling: false,
-            approximate_matching: false,
-            softmatching_score_threshold: 0.4,
-            softmatching_bidirectional: false,
-            precision: 'bf16',
-        },
-        active: false,
-        name: 'SoftMatcher',
-    };
-};
+const toProjectModel = (meta: SupportedModelMetadata, index: number): ModelType => ({
+    id: uuid(),
+    config: meta.default_config,
+    active: index === 0,
+    name: MODEL_TYPE_DISPLAY_NAMES[meta.default_config.model_type] ?? meta.default_config.model_type,
+});
 
 export const useGetModels = () => {
     const { models } = useGetModelsQuery();
+    const supportedModels = useGetSupportedModels();
     const createModel = useCreateModel();
     const hasCreatedModel = useRef(false);
 
-    // TODO: Backend is willing to send default models soon.
-    // Once that is done, we can remove this model creation logic.
     useEffect(() => {
         if (models.length === 0 && !hasCreatedModel.current) {
             hasCreatedModel.current = true;
-            createModel(getDefaultPerDINOModel(uuid()));
-            createModel(getDefaultSoftMatcherModel(uuid()));
-            createModel(getDefaultMatcherModel(uuid()));
+            supportedModels.forEach((meta, index) => {
+                createModel(toProjectModel(meta, index));
+            });
         }
-    }, [models.length, createModel]);
+    }, [models.length, createModel, supportedModels]);
 
     return models;
 };
+
+
+// const getDefaultMatcherModel = (id: string): MatcherModel => {
+//     return {
+//         id,
+//         config: {
+//             confidence_threshold: 0.38,
+//             model_type: 'matcher',
+//             num_background_points: 2,
+//             num_foreground_points: 40,
+//             precision: 'bf16',
+//             sam_model: 'SAM-HQ-tiny',
+//             encoder_model: 'dinov3_small',
+//             use_mask_refinement: false,
+//         },
+//         active: false,
+//         name: `Matcher`,
+//     };
+// };
+//
+// const getDefaultPerDINOModel = (id: string): PerDINOModel => {
+//     return {
+//         id,
+//         config: {
+//             model_type: 'perdino',
+//             encoder_model: 'dinov3_small',
+//             sam_model: 'SAM-HQ-tiny',
+//             num_foreground_points: 90,
+//             num_background_points: 2,
+//             num_grid_cells: 16,
+//             point_selection_threshold: 0.65,
+//             confidence_threshold: 0.42,
+//             precision: 'bf16',
+//         },
+//         active: true,
+//         name: 'PerDINO',
+//     };
+// };
+//
+// const getDefaultSoftMatcherModel = (id: string): SoftMatcherModel => {
+//     return {
+//         id,
+//         config: {
+//             model_type: 'soft_matcher',
+//             sam_model: 'SAM-HQ-tiny',
+//             encoder_model: 'dinov3_small',
+//             num_foreground_points: 40,
+//             num_background_points: 2,
+//             confidence_threshold: 0.42,
+//             use_sampling: false,
+//             use_spatial_sampling: false,
+//             approximate_matching: false,
+//             softmatching_score_threshold: 0.4,
+//             softmatching_bidirectional: false,
+//             precision: 'bf16',
+//         },
+//         active: false,
+//         name: 'SoftMatcher',
+//     };
+// };
+//
+// export const useGetModels = () => {
+//     const { models } = useGetModelsQuery();
+//     const createModel = useCreateModel();
+//     const hasCreatedModel = useRef(false);
+//
+//     // TODO: Backend is willing to send default models soon.
+//     // Once that is done, we can remove this model creation logic.
+//     useEffect(() => {
+//         if (models.length === 0 && !hasCreatedModel.current) {
+//             hasCreatedModel.current = true;
+//             createModel(getDefaultPerDINOModel(uuid()));
+//             createModel(getDefaultSoftMatcherModel(uuid()));
+//             createModel(getDefaultMatcherModel(uuid()));
+//         }
+//     }, [models.length, createModel]);
+//
+//     return models;
+// };

--- a/application/ui/src/features/prompts/models/api/use-get-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-models.ts
@@ -4,12 +4,13 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { useGetSupportedModels, type SupportedModelMetadata } from './use-get-supported-models';
-import { $api, MatcherModel, ModelListType, ModelType, PerDINOModel, SoftMatcherModel } from '@/api';
+
+import { $api, ModelListType, ModelType } from '@/api';
 import { useProjectIdentifier } from '@/hooks';
 import { v4 as uuid } from 'uuid';
 
 import { useCreateModel } from './use-create-model';
+import { useGetSupportedModels, type SupportedModelMetadata } from './use-get-supported-models';
 
 const useGetModelsQuery = (): ModelListType => {
     const { projectId } = useProjectIdentifier();
@@ -23,7 +24,6 @@ const useGetModelsQuery = (): ModelListType => {
 
     return data;
 };
-
 
 const MODEL_TYPE_DISPLAY_NAMES: Record<string, string> = {
     matcher: 'Matcher',
@@ -56,82 +56,3 @@ export const useGetModels = () => {
 
     return models;
 };
-
-
-// const getDefaultMatcherModel = (id: string): MatcherModel => {
-//     return {
-//         id,
-//         config: {
-//             confidence_threshold: 0.38,
-//             model_type: 'matcher',
-//             num_background_points: 2,
-//             num_foreground_points: 40,
-//             precision: 'bf16',
-//             sam_model: 'SAM-HQ-tiny',
-//             encoder_model: 'dinov3_small',
-//             use_mask_refinement: false,
-//         },
-//         active: false,
-//         name: `Matcher`,
-//     };
-// };
-//
-// const getDefaultPerDINOModel = (id: string): PerDINOModel => {
-//     return {
-//         id,
-//         config: {
-//             model_type: 'perdino',
-//             encoder_model: 'dinov3_small',
-//             sam_model: 'SAM-HQ-tiny',
-//             num_foreground_points: 90,
-//             num_background_points: 2,
-//             num_grid_cells: 16,
-//             point_selection_threshold: 0.65,
-//             confidence_threshold: 0.42,
-//             precision: 'bf16',
-//         },
-//         active: true,
-//         name: 'PerDINO',
-//     };
-// };
-//
-// const getDefaultSoftMatcherModel = (id: string): SoftMatcherModel => {
-//     return {
-//         id,
-//         config: {
-//             model_type: 'soft_matcher',
-//             sam_model: 'SAM-HQ-tiny',
-//             encoder_model: 'dinov3_small',
-//             num_foreground_points: 40,
-//             num_background_points: 2,
-//             confidence_threshold: 0.42,
-//             use_sampling: false,
-//             use_spatial_sampling: false,
-//             approximate_matching: false,
-//             softmatching_score_threshold: 0.4,
-//             softmatching_bidirectional: false,
-//             precision: 'bf16',
-//         },
-//         active: false,
-//         name: 'SoftMatcher',
-//     };
-// };
-//
-// export const useGetModels = () => {
-//     const { models } = useGetModelsQuery();
-//     const createModel = useCreateModel();
-//     const hasCreatedModel = useRef(false);
-//
-//     // TODO: Backend is willing to send default models soon.
-//     // Once that is done, we can remove this model creation logic.
-//     useEffect(() => {
-//         if (models.length === 0 && !hasCreatedModel.current) {
-//             hasCreatedModel.current = true;
-//             createModel(getDefaultPerDINOModel(uuid()));
-//             createModel(getDefaultSoftMatcherModel(uuid()));
-//             createModel(getDefaultMatcherModel(uuid()));
-//         }
-//     }, [models.length, createModel]);
-//
-//     return models;
-// };

--- a/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
@@ -10,7 +10,7 @@ export type SupportedModelMetadata = components['schemas']['SupportedModelMetada
 export type SupportedPromptType = components['schemas']['SupportedPromptType'];
 
 export const useGetSupportedModels = () => {
-    const { data } = $api.useSuspenseQuery('get', '/api/v1/supported-models', {
+    const { data } = $api.useSuspenseQuery('get', '/api/v1/system/supported-models', {
         params: { query: { offset: 0, limit: 20 } },
     });
 

--- a/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
@@ -4,10 +4,10 @@
  */
 
 import { $api } from '@/api';
-import type { components } from '@/api/openapi-spec';
+import type { SchemaSupportedModelMetadataSchema, SchemaSupportedPromptType } from '@/api/openapi-spec';
 
-export type SupportedModelMetadata = components['schemas']['SupportedModelMetadataSchema'];
-export type SupportedPromptType = components['schemas']['SupportedPromptType'];
+export type SupportedModelMetadata = SchemaSupportedModelMetadataSchema;
+export type SupportedPromptType = SchemaSupportedPromptType;
 
 export const useGetSupportedModels = () => {
     const { data } = $api.useSuspenseQuery('get', '/api/v1/system/supported-models', {

--- a/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
@@ -1,5 +1,11 @@
+/**
+ * Copyright (C) 2025 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { $api } from '@/api';
 import type { components } from '@/api/openapi-spec';
+
 export type SupportedModelMetadata = components['schemas']['SupportedModelMetadataSchema'];
 export type SupportedPromptType = components['schemas']['SupportedPromptType'];
 

--- a/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-supported-models.ts
@@ -1,0 +1,12 @@
+import { $api } from '@/api';
+import type { components } from '@/api/openapi-spec';
+export type SupportedModelMetadata = components['schemas']['SupportedModelMetadataSchema'];
+export type SupportedPromptType = components['schemas']['SupportedPromptType'];
+
+export const useGetSupportedModels = () => {
+    const { data } = $api.useSuspenseQuery('get', '/api/v1/supported-models', {
+        params: { query: { offset: 0, limit: 20 } },
+    });
+
+    return data.models;
+};

--- a/application/ui/src/features/prompts/models/api/use-update-model.ts
+++ b/application/ui/src/features/prompts/models/api/use-update-model.ts
@@ -15,6 +15,7 @@ const useUpdateModelMutation = (projectId: string) => {
         meta: {
             invalidates: [
                 ['get', '/api/v1/projects/{project_id}/models', { params: { path: { project_id: projectId } } }],
+                ['get', '/api/v1/projects/{project_id}/prompts', { params: { path: { project_id: projectId } } }],
             ],
             error: {
                 notify: true,

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
@@ -23,7 +23,7 @@ const ENCODER_MODELS = [
 // ATM backend does not provide a list of available models, so we have to hardcode them here.
 type EncoderModel = (typeof ENCODER_MODELS)[number]['value'];
 
-type DecoderModel = ModelType['config']['sam_model'];
+type DecoderModel = MatcherModel['config']['sam_model'];
 
 const DECODER_MODELS: { label: string; value: DecoderModel }[] = [
     {

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
@@ -5,12 +5,12 @@
 
 import { FormEvent, useState } from 'react';
 
-import { MatcherModel, ModelType, PerDINOModel, SoftMatcherModel } from '@/api';
+import { MatcherModel, ModelType, PerDINOModel, Sam3Model, SoftMatcherModel } from '@/api';
 import { Button, ButtonGroup, Content, Dialog, Divider, Flex, Form, Heading, Item, Picker, Switch } from '@geti/ui';
 
 import { useUpdateModel } from '../../api/use-update-model';
 import { NumberField } from './number-field.component';
-import { isMatcherModel, isPerDINOModel, isSoftMatcherModel } from './utils';
+import { isMatcherModel, isPerDINOModel, isSam3Model, isSoftMatcherModel } from './utils';
 
 const ENCODER_MODELS = [
     { label: 'DINOv3 Small', value: 'dinov3_small' },
@@ -475,6 +475,80 @@ const SoftMatcherConfiguration = ({ model, onClose }: SoftMatcherConfigurationPr
     );
 };
 
+interface Sam3ConfigurationProps {
+    model: Sam3Model;
+    onClose: () => void;
+}
+
+const Sam3Configuration = ({ model, onClose }: Sam3ConfigurationProps) => {
+    const [confidenceThreshold, setConfidenceThreshold] = useState<number>(model.config.confidence_threshold);
+    const [resolution, setResolution] = useState<number>(model.config.resolution);
+    const [precision, setPrecision] = useState<Precision>(model.config.precision as Precision);
+
+    const updateModelMutation = useUpdateModel();
+
+    const isConfigureButtonDisabled =
+        confidenceThreshold === model.config.confidence_threshold &&
+        resolution === model.config.resolution &&
+        precision === model.config.precision;
+
+    const updateModel = (event: FormEvent) => {
+        event.preventDefault();
+
+        updateModelMutation.mutate(
+            {
+                active: model.active,
+                name: model.name,
+                id: model.id,
+                config: {
+                    model_type: model.config.model_type,
+                    confidence_threshold: confidenceThreshold,
+                    resolution,
+                    precision,
+                },
+            },
+            onClose
+        );
+    };
+
+    return (
+        <Form onSubmit={updateModel}>
+            <Flex direction={'column'} gap={'size-200'}>
+                <NumberField
+                    label={'Confidence threshold'}
+                    minValue={0}
+                    maxValue={1}
+                    step={0.01}
+                    onChange={setConfidenceThreshold}
+                    value={confidenceThreshold}
+                />
+                <NumberField
+                    label={'Resolution'}
+                    minValue={224}
+                    maxValue={2048}
+                    step={16}
+                    onChange={setResolution}
+                    value={resolution}
+                />
+                <Selection label={'Precision'} value={precision} onChange={setPrecision} items={PRECISIONS} />
+                <ButtonGroup align={'end'}>
+                    <Button variant={'secondary'} onPress={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type={'submit'}
+                        variant={'primary'}
+                        isPending={updateModelMutation.isPending}
+                        isDisabled={isConfigureButtonDisabled}
+                    >
+                        Configure
+                    </Button>
+                </ButtonGroup>
+            </Flex>
+        </Form>
+    );
+};
+
 interface ModelConfigurationDialogProps {
     model: ModelType;
     onClose: () => void;
@@ -492,6 +566,8 @@ export const ModelConfigurationDialog = ({ model, onClose }: ModelConfigurationD
                     <PerDINOConfiguration model={model} onClose={onClose} />
                 ) : isSoftMatcherModel(model) ? (
                     <SoftMatcherConfiguration model={model} onClose={onClose} />
+                ) : isSam3Model(model) ? (
+                    <Sam3Configuration model={model} onClose={onClose} />
                 ) : null}
             </Content>
         </Dialog>

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
@@ -134,7 +134,7 @@ describe('ModelConfigurationDialog', () => {
         expect(modelConfigurationDialogPage.configureButton).toBeEnabled();
         await modelConfigurationDialogPage.changePrecision(model.config.precision.toUpperCase());
         expect(modelConfigurationDialogPage.configureButton).toBeDisabled();
-    }, 15_000);
+    });
 
     it('configures the model', async () => {
         let body: ModelUpdateType;
@@ -185,7 +185,7 @@ describe('ModelConfigurationDialog', () => {
         });
 
         expect(mockOnClose).toHaveBeenCalled();
-    }, 15_000);
+    });
 
     it('closes the dialog', async () => {
         const onClose = vi.fn();

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ModelType, ModelUpdateType } from '@/api';
+import { MatcherModel, ModelType, ModelUpdateType } from '@/api';
 import { getMockedModel, getMockedSam3Model, render } from '@/test-utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -90,11 +90,8 @@ describe('ModelConfigurationDialog', () => {
     });
 
     it('enables configure button when any of the parameters has been changes', async () => {
-        const mockedModel = getMockedModel();
-
         const model = getMockedModel({
             config: {
-                ...mockedModel.config,
                 model_type: 'matcher',
                 num_foreground_points: 10,
                 num_background_points: 10,
@@ -103,8 +100,8 @@ describe('ModelConfigurationDialog', () => {
                 encoder_model: 'dinov3_small',
                 use_mask_refinement: true,
                 precision: 'bf16',
-            },
-        });
+            } as MatcherModel['config'],
+        }) as MatcherModel;
 
         const { modelConfigurationDialogPage } = renderModelConfigurationDialog({ model });
 

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { ModelType, ModelUpdateType } from '@/api';
-import { getMockedModel, render } from '@/test-utils';
+import { getMockedModel, getMockedSam3Model, render } from '@/test-utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
@@ -41,6 +41,10 @@ class ModelConfigurationDialogPage {
 
     async changeConfidenceThreshold(value: number) {
         await this.changeNumberField('Confidence threshold', value);
+    }
+
+    async changeResolution(value: number) {
+        await this.changeNumberField('Resolution', value);
     }
 
     private async changeSelection(field: string, value: string) {
@@ -133,7 +137,7 @@ describe('ModelConfigurationDialog', () => {
         expect(modelConfigurationDialogPage.configureButton).toBeEnabled();
         await modelConfigurationDialogPage.changePrecision(model.config.precision.toUpperCase());
         expect(modelConfigurationDialogPage.configureButton).toBeDisabled();
-    });
+    }, 15_000);
 
     it('configures the model', async () => {
         let body: ModelUpdateType;
@@ -184,7 +188,7 @@ describe('ModelConfigurationDialog', () => {
         });
 
         expect(mockOnClose).toHaveBeenCalled();
-    });
+    }, 15_000);
 
     it('closes the dialog', async () => {
         const onClose = vi.fn();
@@ -194,5 +198,82 @@ describe('ModelConfigurationDialog', () => {
         await modelConfigurationDialogPage.closeDialog();
 
         expect(onClose).toHaveBeenCalled();
+    });
+
+    describe('Sam3Configuration', () => {
+        it('renders SAM3 config fields', () => {
+            const model = getMockedSam3Model();
+            renderModelConfigurationDialog({ model });
+
+            expect(screen.getByRole('textbox', { name: 'Confidence threshold' })).toBeVisible();
+            expect(screen.getByRole('textbox', { name: 'Resolution' })).toBeVisible();
+            expect(screen.getByRole('button', { name: /Precision/ })).toBeVisible();
+
+            // SAM3 should NOT show encoder/decoder model pickers or foreground/background points
+            expect(screen.queryByRole('button', { name: /Encoder model/ })).not.toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: /Decoder model/ })).not.toBeInTheDocument();
+            expect(screen.queryByRole('textbox', { name: 'Number of foreground points' })).not.toBeInTheDocument();
+            expect(screen.queryByRole('textbox', { name: 'Number of background points' })).not.toBeInTheDocument();
+        });
+
+        it('disables configure button when SAM3 parameters have not been changed', () => {
+            const model = getMockedSam3Model();
+            const { modelConfigurationDialogPage } = renderModelConfigurationDialog({ model });
+
+            expect(modelConfigurationDialogPage.configureButton).toBeDisabled();
+        });
+
+        it('enables configure button when SAM3 confidence threshold is changed', async () => {
+            const model = getMockedSam3Model();
+            const { modelConfigurationDialogPage } = renderModelConfigurationDialog({ model });
+
+            await modelConfigurationDialogPage.changeConfidenceThreshold(0.8);
+            expect(modelConfigurationDialogPage.configureButton).toBeEnabled();
+
+            await modelConfigurationDialogPage.changeConfidenceThreshold(model.config.confidence_threshold);
+            expect(modelConfigurationDialogPage.configureButton).toBeDisabled();
+        });
+
+        it('enables configure button when SAM3 resolution is changed', async () => {
+            const model = getMockedSam3Model();
+            const { modelConfigurationDialogPage } = renderModelConfigurationDialog({ model });
+
+            await modelConfigurationDialogPage.changeResolution(512);
+            expect(modelConfigurationDialogPage.configureButton).toBeEnabled();
+        });
+
+        it('configures SAM3 model', async () => {
+            let body: ModelUpdateType;
+            server.use(
+                http.put('/api/v1/projects/{project_id}/models/{model_id}', async ({ request }) => {
+                    body = await request.json();
+                    return HttpResponse.json(request.body);
+                })
+            );
+
+            const model = getMockedSam3Model({ active: true });
+            const mockOnClose = vi.fn();
+            const { modelConfigurationDialogPage } = renderModelConfigurationDialog({
+                model,
+                onClose: mockOnClose,
+            });
+
+            await modelConfigurationDialogPage.changeConfidenceThreshold(0.7);
+            await modelConfigurationDialogPage.changeResolution(512);
+            await modelConfigurationDialogPage.changePrecision('BF16');
+
+            await modelConfigurationDialogPage.configureModel();
+
+            await waitFor(() => {
+                expect(body.config).toEqual({
+                    model_type: 'sam3',
+                    confidence_threshold: 0.7,
+                    resolution: 512,
+                    precision: 'bf16',
+                });
+            });
+
+            expect(mockOnClose).toHaveBeenCalled();
+        });
     });
 });

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.test.ts
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2025 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getMockedModel, getMockedSam3Model } from '@/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import { isMatcherModel, isPerDINOModel, isSam3Model, isSoftMatcherModel } from './utils';
+
+describe('model type guards', () => {
+    it('isMatcherModel returns true for matcher models', () => {
+        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'matcher' } });
+        expect(isMatcherModel(model)).toBe(true);
+        expect(isPerDINOModel(model)).toBe(false);
+        expect(isSoftMatcherModel(model)).toBe(false);
+        expect(isSam3Model(model)).toBe(false);
+    });
+
+    it('isPerDINOModel returns true for perdino models', () => {
+        const model = getMockedModel();
+        expect(isPerDINOModel(model)).toBe(true);
+        expect(isMatcherModel(model)).toBe(false);
+    });
+
+    it('isSoftMatcherModel returns true for soft_matcher models', () => {
+        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'soft_matcher' } });
+        expect(isSoftMatcherModel(model)).toBe(true);
+        expect(isMatcherModel(model)).toBe(false);
+    });
+
+    it('isSam3Model returns true for sam3 models', () => {
+        const model = getMockedSam3Model();
+        expect(isSam3Model(model)).toBe(true);
+        expect(isMatcherModel(model)).toBe(false);
+        expect(isPerDINOModel(model)).toBe(false);
+        expect(isSoftMatcherModel(model)).toBe(false);
+    });
+});

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.test.ts
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.test.ts
@@ -4,13 +4,14 @@
  */
 
 import { getMockedModel, getMockedSam3Model } from '@/test-utils';
+import type { MatcherModel, SoftMatcherModel } from '@/api';
 import { describe, expect, it } from 'vitest';
 
 import { isMatcherModel, isPerDINOModel, isSam3Model, isSoftMatcherModel } from './utils';
 
 describe('model type guards', () => {
     it('isMatcherModel returns true for matcher models', () => {
-        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'matcher' } });
+        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'matcher' } as MatcherModel['config'] });
         expect(isMatcherModel(model)).toBe(true);
         expect(isPerDINOModel(model)).toBe(false);
         expect(isSoftMatcherModel(model)).toBe(false);
@@ -24,7 +25,7 @@ describe('model type guards', () => {
     });
 
     it('isSoftMatcherModel returns true for soft_matcher models', () => {
-        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'soft_matcher' } });
+        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'soft_matcher' } as SoftMatcherModel['config'] });
         expect(isSoftMatcherModel(model)).toBe(true);
         expect(isMatcherModel(model)).toBe(false);
     });

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.test.ts
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.test.ts
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getMockedModel, getMockedSam3Model } from '@/test-utils';
 import type { MatcherModel, SoftMatcherModel } from '@/api';
+import { getMockedModel, getMockedSam3Model } from '@/test-utils';
 import { describe, expect, it } from 'vitest';
 
 import { isMatcherModel, isPerDINOModel, isSam3Model, isSoftMatcherModel } from './utils';
 
 describe('model type guards', () => {
     it('isMatcherModel returns true for matcher models', () => {
-        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'matcher' } as MatcherModel['config'] });
+        const model = getMockedModel({
+            config: { ...getMockedModel().config, model_type: 'matcher' } as MatcherModel['config'],
+        });
         expect(isMatcherModel(model)).toBe(true);
         expect(isPerDINOModel(model)).toBe(false);
         expect(isSoftMatcherModel(model)).toBe(false);
@@ -25,7 +27,9 @@ describe('model type guards', () => {
     });
 
     it('isSoftMatcherModel returns true for soft_matcher models', () => {
-        const model = getMockedModel({ config: { ...getMockedModel().config, model_type: 'soft_matcher' } as SoftMatcherModel['config'] });
+        const model = getMockedModel({
+            config: { ...getMockedModel().config, model_type: 'soft_matcher' } as SoftMatcherModel['config'],
+        });
         expect(isSoftMatcherModel(model)).toBe(true);
         expect(isMatcherModel(model)).toBe(false);
     });

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.ts
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/utils.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MatcherModel, ModelType, PerDINOModel, SoftMatcherModel } from '@/api';
+import { MatcherModel, ModelType, PerDINOModel, Sam3Model, SoftMatcherModel } from '@/api';
 
 export const isMatcherModel = (m: ModelType): m is MatcherModel => m.config.model_type === 'matcher';
 export const isPerDINOModel = (m: ModelType): m is PerDINOModel => m.config.model_type === 'perdino';
 export const isSoftMatcherModel = (m: ModelType): m is SoftMatcherModel => m.config.model_type === 'soft_matcher';
+export const isSam3Model = (m: ModelType): m is Sam3Model => m.config.model_type === 'sam3';

--- a/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.test.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import { getMockedModel, getMockedSam3Model, render } from '@/test-utils';
+import type { MatcherModel } from '@/api';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 
@@ -80,7 +81,7 @@ describe('ModelToolbar', () => {
                             id: 'matcher-1',
                             name: 'Matcher',
                             active: true,
-                            config: { ...getMockedModel().config, model_type: 'matcher' },
+                            config: { ...getMockedModel().config, model_type: 'matcher' } as MatcherModel['config'],
                         }),
                         getMockedSam3Model({ id: 'sam3-1', name: 'SAM3', active: false }),
                     ],
@@ -110,7 +111,7 @@ describe('ModelToolbar', () => {
                             id: 'matcher-1',
                             name: 'Matcher',
                             active: true,
-                            config: { ...getMockedModel().config, model_type: 'matcher' },
+                            config: { ...getMockedModel().config, model_type: 'matcher' } as MatcherModel['config'],
                         }),
                         getMockedSam3Model({ id: 'sam3-1', name: 'SAM3', active: false }),
                     ],

--- a/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.test.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.test.tsx
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getMockedModel, render } from '@/test-utils';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { getMockedModel, getMockedSam3Model, render } from '@/test-utils';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 
 import { http, server } from '../../../../setup-test';
 import { ModelToolbar } from './model-toolbar.component';
+
+const renderToolbar = (route = '/projects/1?mode=visual') =>
+    render(<ModelToolbar />, { route, path: '/projects/:projectId' });
 
 describe('ModelToolbar', () => {
     it('does not render picker if there are no models', async () => {
@@ -24,9 +27,9 @@ describe('ModelToolbar', () => {
     });
 
     it('renders models correctly', async () => {
-        render(<ModelToolbar />);
+        renderToolbar();
 
-        const pickerButton = await screen.findByRole('button', { name: /Mega model/i });
+        const pickerButton = await screen.findByRole('button', { name: /Mega model/i }, { timeout: 5000 });
         fireEvent.click(pickerButton);
 
         const listbox = screen.getByRole('listbox');
@@ -34,19 +37,26 @@ describe('ModelToolbar', () => {
     });
 
     it('changes selected model when a different option is clicked', async () => {
+        let activeModelId = 'model-1';
+
         server.use(
             http.get('/api/v1/projects/{project_id}/models', () => {
                 return HttpResponse.json({
                     models: [
-                        getMockedModel({ id: 'model-1', name: 'Mega model', active: true }),
-                        getMockedModel({ id: 'model-2', name: 'Tiny model', active: false }),
+                        getMockedModel({ id: 'model-1', name: 'Mega model', active: activeModelId === 'model-1' }),
+                        getMockedModel({ id: 'model-2', name: 'Tiny model', active: activeModelId === 'model-2' }),
                     ],
-                    pagination: { total: 0, count: 0, offset: 0, limit: 10 },
+                    pagination: { total: 2, count: 2, offset: 0, limit: 10 },
                 });
+            }),
+            http.put('/api/v1/projects/{project_id}/models/{model_id}', async ({ request, params }) => {
+                activeModelId = params.model_id as string;
+                const body = await request.json();
+                return HttpResponse.json(body);
             })
         );
 
-        render(<ModelToolbar />);
+        renderToolbar();
 
         const pickerButton = await screen.findByRole('button', { name: /Mega model/i });
         fireEvent.click(pickerButton);
@@ -57,7 +67,66 @@ describe('ModelToolbar', () => {
 
         fireEvent.click(screen.getByRole('option', { name: 'Tiny model' }));
 
-        const pickerButtonTwo = screen.getByRole('button', { name: /Tiny model/i });
+        const pickerButtonTwo = await screen.findByRole('button', { name: /Tiny model/i });
         expect(within(pickerButtonTwo).getByText('Tiny model')).toBeVisible();
+    });
+
+    it('only shows visual-compatible models in visual prompt mode', async () => {
+        server.use(
+            http.get('/api/v1/projects/{project_id}/models', () => {
+                return HttpResponse.json({
+                    models: [
+                        getMockedModel({
+                            id: 'matcher-1',
+                            name: 'Matcher',
+                            active: true,
+                            config: { ...getMockedModel().config, model_type: 'matcher' },
+                        }),
+                        getMockedSam3Model({ id: 'sam3-1', name: 'SAM3', active: false }),
+                    ],
+                    pagination: { total: 2, count: 2, offset: 0, limit: 10 },
+                });
+            })
+        );
+
+        // Default mode is "visual" — matcher supports visual_polygon, SAM3 supports visual_rectangle
+        // Both should be visible
+        renderToolbar('/projects/1?mode=visual');
+
+        const pickerButton = await screen.findByRole('button', { name: /Matcher/i });
+        fireEvent.click(pickerButton);
+
+        const listbox = screen.getByRole('listbox');
+        expect(within(listbox).getByRole('option', { name: 'Matcher' })).toBeVisible();
+        expect(within(listbox).getByRole('option', { name: 'SAM3' })).toBeVisible();
+    });
+
+    it('only shows text-compatible models in text prompt mode', async () => {
+        server.use(
+            http.get('/api/v1/projects/{project_id}/models', () => {
+                return HttpResponse.json({
+                    models: [
+                        getMockedModel({
+                            id: 'matcher-1',
+                            name: 'Matcher',
+                            active: true,
+                            config: { ...getMockedModel().config, model_type: 'matcher' },
+                        }),
+                        getMockedSam3Model({ id: 'sam3-1', name: 'SAM3', active: false }),
+                    ],
+                    pagination: { total: 2, count: 2, offset: 0, limit: 10 },
+                });
+            })
+        );
+
+        // Text mode — only SAM3 supports "text"
+        renderToolbar('/projects/1?mode=text');
+
+        // SAM3 is the only text-compatible model
+        await waitFor(() => {
+            expect(screen.queryByText('Matcher')).not.toBeInTheDocument();
+        });
+
+        expect(await screen.findByRole('button', { name: /SAM3/i })).toBeVisible();
     });
 });

--- a/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.test.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.test.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getMockedModel, getMockedSam3Model, render } from '@/test-utils';
 import type { MatcherModel } from '@/api';
+import { getMockedModel, getMockedSam3Model, render } from '@/test-utils';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 

--- a/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.tsx
@@ -22,7 +22,7 @@ const isModelCompatible = (
 ): boolean => {
     const supportedTypes = promptTypesMap.get(model.config.model_type) ?? [];
     if (promptMode === 'visual') {
-        return supportedTypes.some((t) => t === 'visual_polygon' || t === 'visual_rectangle');
+        return supportedTypes.some((t) => t.startsWith('visual'));
     }
     return supportedTypes.includes('text');
 };

--- a/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.tsx
@@ -10,10 +10,10 @@ import { usePromptMode, type PromptMode } from '@/hooks';
 import { Flex, Item, Loading, Picker, Text, View } from '@geti/ui';
 
 import { useGetModels } from '../api/use-get-models';
+import { type SupportedPromptType } from '../api/use-get-supported-models';
 import { useUpdateModel } from '../api/use-update-model';
 import { useSupportedPromptTypesMap } from '../use-supported-prompt-types';
 import { ModelConfiguration } from './model-configuration/model-configuration.component';
-import { type SupportedPromptType } from '../api/use-get-supported-models';
 
 const isModelCompatible = (
     model: ModelType,

--- a/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-toolbar.component.tsx
@@ -3,13 +3,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Key, Suspense } from 'react';
+import { Key, Suspense, useEffect, useRef } from 'react';
 
+import { ModelType } from '@/api';
+import { usePromptMode, type PromptMode } from '@/hooks';
 import { Flex, Item, Loading, Picker, Text, View } from '@geti/ui';
 
 import { useGetModels } from '../api/use-get-models';
 import { useUpdateModel } from '../api/use-update-model';
+import { useSupportedPromptTypesMap } from '../use-supported-prompt-types';
 import { ModelConfiguration } from './model-configuration/model-configuration.component';
+import { type SupportedPromptType } from '../api/use-get-supported-models';
+
+const isModelCompatible = (
+    model: ModelType,
+    promptMode: PromptMode,
+    promptTypesMap: Map<string, SupportedPromptType[]>
+): boolean => {
+    const supportedTypes = promptTypesMap.get(model.config.model_type) ?? [];
+    if (promptMode === 'visual') {
+        return supportedTypes.some((t) => t === 'visual_polygon' || t === 'visual_rectangle');
+    }
+    return supportedTypes.includes('text');
+};
 
 export const ModelToolbar = () => {
     return (
@@ -22,9 +38,39 @@ export const ModelToolbar = () => {
 };
 
 const ModelToolbarContent = () => {
-    const models = useGetModels();
+    const allModels = useGetModels();
     const updateModel = useUpdateModel();
-    const activeModel = models.find((model) => model.active) ?? models[0];
+    const [promptMode] = usePromptMode();
+    const promptTypesMap = useSupportedPromptTypesMap();
+    const previousPromptMode = useRef(promptMode);
+
+    // Filter models compatible with the current prompt mode
+    const models = allModels.filter((model) => isModelCompatible(model, promptMode, promptTypesMap));
+
+    const activeModel = models.find((m) => m.active) ?? models[0];
+
+    // Auto-select first compatible model when prompt mode changes
+    // and the currently active model is not compatible
+    useEffect(() => {
+        if (previousPromptMode.current === promptMode) {
+            return;
+        }
+        previousPromptMode.current = promptMode;
+
+        if (models.length === 0) {
+            return;
+        }
+
+        const currentActiveModel = allModels.find((m) => m.active);
+
+        // If the active model is already compatible, no action needed
+        if (currentActiveModel && isModelCompatible(currentActiveModel, promptMode, promptTypesMap)) {
+            return;
+        }
+
+        // Activate the first compatible model
+        updateModel.mutate({ ...models[0], active: true });
+    }, [promptMode, models, allModels, promptTypesMap, updateModel]);
 
     const handleSelectionChange = (key: Key | null) => {
         const selectedModel = models.find((model) => model.id === key);
@@ -47,14 +93,14 @@ const ModelToolbarContent = () => {
             <Picker
                 isQuiet
                 label={'Model'}
-                defaultSelectedKey={activeModel.id}
+                selectedKey={activeModel?.id}
                 onSelectionChange={handleSelectionChange}
                 items={models}
             >
                 {(item) => <Item key={item.id}>{item.name}</Item>}
             </Picker>
 
-            <ModelConfiguration model={activeModel} />
+            {activeModel && <ModelConfiguration model={activeModel} />}
         </Flex>
     );
 };

--- a/application/ui/src/features/prompts/models/use-supported-prompt-types.ts
+++ b/application/ui/src/features/prompts/models/use-supported-prompt-types.ts
@@ -1,0 +1,13 @@
+import { useGetSupportedModels, type SupportedPromptType } from './api/use-get-supported-models';
+
+/**
+ * Build a map from model_type → supported_prompt_types using the
+ * /api/v1/supported-models endpoint response.
+ */
+export const useSupportedPromptTypesMap = (): Map<string, SupportedPromptType[]> => {
+    const supportedModels = useGetSupportedModels();
+
+    return new Map(
+        supportedModels.map((m) => [m.default_config.model_type, m.supported_prompt_types])
+    );
+};

--- a/application/ui/src/features/prompts/models/use-supported-prompt-types.ts
+++ b/application/ui/src/features/prompts/models/use-supported-prompt-types.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (C) 2025 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { useGetSupportedModels, type SupportedPromptType } from './api/use-get-supported-models';
 
 /**
@@ -7,7 +12,5 @@ import { useGetSupportedModels, type SupportedPromptType } from './api/use-get-s
 export const useSupportedPromptTypesMap = (): Map<string, SupportedPromptType[]> => {
     const supportedModels = useGetSupportedModels();
 
-    return new Map(
-        supportedModels.map((m) => [m.default_config.model_type, m.supported_prompt_types])
-    );
+    return new Map(supportedModels.map((m) => [m.default_config.model_type, m.supported_prompt_types]));
 };

--- a/application/ui/src/features/prompts/models/use-supported-prompt-types.ts
+++ b/application/ui/src/features/prompts/models/use-supported-prompt-types.ts
@@ -7,7 +7,7 @@ import { useGetSupportedModels, type SupportedPromptType } from './api/use-get-s
 
 /**
  * Build a map from model_type → supported_prompt_types using the
- * /api/v1/supported-models endpoint response.
+ * /api/v1/system/supported-models endpoint response.
  */
 export const useSupportedPromptTypesMap = (): Map<string, SupportedPromptType[]> => {
     const supportedModels = useGetSupportedModels();

--- a/application/ui/src/features/prompts/models/utils.test.ts
+++ b/application/ui/src/features/prompts/models/utils.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { SupportedPromptType } from './api/use-get-supported-models';
+import { getAnnotationTypeFromPromptTypes } from './utils';
+
+describe('getAnnotationTypeFromPromptTypes', () => {
+    it('returns "rectangle" when supported types include visual_rectangle', () => {
+        const types: SupportedPromptType[] = ['text', 'visual_rectangle'];
+        expect(getAnnotationTypeFromPromptTypes(types)).toBe('rectangle');
+    });
+
+    it('returns "polygon" when supported types include visual_polygon only', () => {
+        const types: SupportedPromptType[] = ['visual_polygon'];
+        expect(getAnnotationTypeFromPromptTypes(types)).toBe('polygon');
+    });
+
+    it('returns "polygon" when supported types is empty', () => {
+        expect(getAnnotationTypeFromPromptTypes([])).toBe('polygon');
+    });
+
+    it('returns "polygon" when supported types include only text', () => {
+        const types: SupportedPromptType[] = ['text'];
+        expect(getAnnotationTypeFromPromptTypes(types)).toBe('polygon');
+    });
+
+    it('returns "rectangle" when both visual_polygon and visual_rectangle are present', () => {
+        const types: SupportedPromptType[] = ['visual_polygon', 'visual_rectangle'];
+        expect(getAnnotationTypeFromPromptTypes(types)).toBe('rectangle');
+    });
+});

--- a/application/ui/src/features/prompts/models/utils.test.ts
+++ b/application/ui/src/features/prompts/models/utils.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2026 Intel Corporation
+ * Copyright (C) 2025 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/application/ui/src/features/prompts/models/utils.ts
+++ b/application/ui/src/features/prompts/models/utils.ts
@@ -3,11 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ModelType } from '@/api';
+import type { ModelType } from '@/api';
+import type { SupportedPromptType } from './api/use-get-supported-models';
 
 export type AnnotationType = 'polygon' | 'rectangle';
 
-// TODO: replace with a real mapping once the backend exposes annotation_type on ModelSchema
-export const getAnnotationTypeForModel = (_model: ModelType): AnnotationType => {
+export const getAnnotationTypeFromPromptTypes = (
+    supportedTypes: SupportedPromptType[]
+): AnnotationType => {
+    if (supportedTypes.includes('visual_rectangle')) {
+        return 'rectangle';
+    }
     return 'polygon';
 };

--- a/application/ui/src/features/prompts/models/utils.ts
+++ b/application/ui/src/features/prompts/models/utils.ts
@@ -3,14 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ModelType } from '@/api';
 import type { SupportedPromptType } from './api/use-get-supported-models';
 
 export type AnnotationType = 'polygon' | 'rectangle';
 
-export const getAnnotationTypeFromPromptTypes = (
-    supportedTypes: SupportedPromptType[]
-): AnnotationType => {
+export const getAnnotationTypeFromPromptTypes = (supportedTypes: SupportedPromptType[]): AnnotationType => {
     if (supportedTypes.includes('visual_rectangle')) {
         return 'rectangle';
     }

--- a/application/ui/src/features/prompts/visual-prompt/visual-prompt-provider.component.tsx
+++ b/application/ui/src/features/prompts/visual-prompt/visual-prompt-provider.component.tsx
@@ -11,6 +11,7 @@ import { useGetPrompt } from './api/use-get-prompt';
 import { useGetPrompts } from './api/use-get-prompts';
 import { useProjectLabels } from './use-project-labels.hook';
 import { usePromptIdFromUrl } from './use-prompt-id-from-url';
+import { useSelectedFrame } from "../../../shared/selected-frame-provider.component";
 
 interface VisualPromptContextProps {
     promptId: string | null;
@@ -60,8 +61,20 @@ export const VisualPromptProvider = ({ children }: VisualPromptProviderProps) =>
     const { promptId, setPromptId } = usePromptIdFromUrl();
     const prompt = useGetPrompt(promptId);
     const prompts = useGetPrompts();
-
+    const { setSelectedFrameId } = useSelectedFrame();
     const { selectedLabel, selectedLabelId, setSelectedLabelId, labels } = useSelectedLabel(prompt);
+
+    // Clear selected prompt if it's no longer in the filtered prompts list
+    // (e.g. after switching to a model that doesn't support its annotation type)
+    useEffect(() => {
+        if (promptId === null) {
+            return;
+        }
+        if (!prompts.some((p) => p.id === promptId)) {
+            setPromptId(null);
+            setSelectedFrameId(null);
+        }
+    }, [promptId, prompts, setPromptId, setSelectedFrameId]);
 
     return (
         <VisualPromptContext

--- a/application/ui/src/features/prompts/visual-prompt/visual-prompt-provider.component.tsx
+++ b/application/ui/src/features/prompts/visual-prompt/visual-prompt-provider.component.tsx
@@ -64,8 +64,9 @@ export const VisualPromptProvider = ({ children }: VisualPromptProviderProps) =>
     const { setSelectedFrameId } = useSelectedFrame();
     const { selectedLabel, selectedLabelId, setSelectedLabelId, labels } = useSelectedLabel(prompt);
 
-    // Clear selected prompt if it's no longer in the filtered prompts list
-    // (e.g. after switching to a model that doesn't support its annotation type)
+    // Clear selected prompt if it's no longer in the filtered prompts list.
+    // This reacts to the prompts query being invalidated after model activation,
+    // which may change the filtered set based on supported annotation types.
     useEffect(() => {
         if (promptId === null) {
             return;

--- a/application/ui/src/features/prompts/visual-prompt/visual-prompt-provider.component.tsx
+++ b/application/ui/src/features/prompts/visual-prompt/visual-prompt-provider.component.tsx
@@ -7,11 +7,11 @@ import { createContext, ReactNode, use, useEffect, useState } from 'react';
 
 import { LabelType, VisualPromptListType, VisualPromptType } from '@/api';
 
+import { useSelectedFrame } from '../../../shared/selected-frame-provider.component';
 import { useGetPrompt } from './api/use-get-prompt';
 import { useGetPrompts } from './api/use-get-prompts';
 import { useProjectLabels } from './use-project-labels.hook';
 import { usePromptIdFromUrl } from './use-prompt-id-from-url';
-import { useSelectedFrame } from "../../../shared/selected-frame-provider.component";
 
 interface VisualPromptContextProps {
     promptId: string | null;

--- a/application/ui/src/setup-test.ts
+++ b/application/ui/src/setup-test.ts
@@ -21,6 +21,10 @@ import fetchPolyfill, { Request as RequestPolyfill } from 'node-fetch';
 
 import { handlers, http } from './api/utils';
 
+import type { components } from './api/openapi-spec';
+
+type SupportedModelsListSchema = components['schemas']['SupportedModelsListSchema'];
+
 const MOCKED_PROJECT_RESPONSE: ProjectType = {
     id: '1',
     name: 'Project #1',
@@ -74,6 +78,64 @@ const MOCKED_SINKS_RESPONSE: SinksListType = {
         offset: 0,
     },
 };
+const MOCKED_SUPPORTED_MODELS_RESPONSE: SupportedModelsListSchema = {
+    pagination: { count: 4, total: 4, offset: 0, limit: 20 },
+    models: [
+        {
+            default_config: {
+                sam_model: 'SAM-HQ-tiny',
+                encoder_model: 'dinov3_small',
+                precision: 'bf16',
+                model_type: 'matcher',
+                num_foreground_points: 5,
+                num_background_points: 3,
+                confidence_threshold: 0.38,
+                use_mask_refinement: false,
+            },
+            supported_prompt_types: ['visual_polygon'],
+        },
+        {
+            default_config: {
+                sam_model: 'SAM-HQ-tiny',
+                encoder_model: 'dinov3_small',
+                precision: 'bf16',
+                model_type: 'perdino',
+                num_foreground_points: 80,
+                num_background_points: 2,
+                num_grid_cells: 16,
+                point_selection_threshold: 0.65,
+                confidence_threshold: 0.01,
+            },
+            supported_prompt_types: ['visual_polygon'],
+        },
+        {
+            default_config: {
+                sam_model: 'SAM-HQ-tiny',
+                encoder_model: 'dinov3_small',
+                precision: 'bf16',
+                model_type: 'soft_matcher',
+                num_foreground_points: 40,
+                num_background_points: 2,
+                confidence_threshold: 0.42,
+                use_sampling: false,
+                use_spatial_sampling: false,
+                approximate_matching: false,
+                softmatching_score_threshold: 0.4,
+                softmatching_bidirectional: false,
+            },
+            supported_prompt_types: ['visual_polygon'],
+        },
+        {
+            default_config: {
+                model_type: 'sam3',
+                confidence_threshold: 0.5,
+                resolution: 1008,
+                precision: 'fp32',
+            },
+            supported_prompt_types: ['text', 'visual_rectangle'],
+        },
+    ],
+};
 const MOCKED_MODELS_RESPONSE: ModelListType = {
     models: [
         {
@@ -123,6 +185,10 @@ const initialHandlers = [
 
     http.get('/api/v1/projects/{project_id}/sinks', () => {
         return HttpResponse.json(MOCKED_SINKS_RESPONSE);
+    }),
+
+    http.get('/api/v1/supported-models', () => {
+        return HttpResponse.json(MOCKED_SUPPORTED_MODELS_RESPONSE);
     }),
 
     http.get('/api/v1/projects/{project_id}/models', () => {

--- a/application/ui/src/setup-test.ts
+++ b/application/ui/src/setup-test.ts
@@ -19,9 +19,8 @@ import { HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import fetchPolyfill, { Request as RequestPolyfill } from 'node-fetch';
 
-import { handlers, http } from './api/utils';
-
 import type { components } from './api/openapi-spec';
+import { handlers, http } from './api/utils';
 
 type SupportedModelsListSchema = components['schemas']['SupportedModelsListSchema'];
 
@@ -194,9 +193,21 @@ const initialHandlers = [
     http.get('/api/v1/projects/{project_id}/models', () => {
         return HttpResponse.json(MOCKED_MODELS_RESPONSE);
     }),
+
+    http.post('/api/v1/projects/{project_id}/models', async ({ request }) => {
+        const body = await request.json();
+        return HttpResponse.json(body, { status: 201 });
+    }),
+
+    http.put('/api/v1/projects/{project_id}/models/{model_id}', async ({ request }) => {
+        const body = await request.json();
+        return HttpResponse.json(body);
+    }),
 ];
 
-const server = setupServer(...handlers, ...initialHandlers);
+// initialHandlers must come first so deterministic mocks take priority
+// over the auto-generated fromOpenApi handlers
+const server = setupServer(...initialHandlers, ...handlers);
 export { http, server };
 
 beforeAll(() => {

--- a/application/ui/src/setup-test.ts
+++ b/application/ui/src/setup-test.ts
@@ -29,7 +29,7 @@ const MOCKED_PROJECT_RESPONSE: ProjectType = {
     name: 'Project #1',
     active: true,
     device: 'cpu',
-    prompt_mode: 'visual',
+    prompt_mode: 'VISUAL',
 };
 const MOCKED_PROJECTS_LIST_RESPONSE: ProjectsListType = {
     projects: [MOCKED_PROJECT_RESPONSE],

--- a/application/ui/src/setup-test.ts
+++ b/application/ui/src/setup-test.ts
@@ -186,7 +186,7 @@ const initialHandlers = [
         return HttpResponse.json(MOCKED_SINKS_RESPONSE);
     }),
 
-    http.get('/api/v1/supported-models', () => {
+    http.get('/api/v1/system/supported-models', () => {
         return HttpResponse.json(MOCKED_SUPPORTED_MODELS_RESPONSE);
     }),
 

--- a/application/ui/src/test-utils/index.ts
+++ b/application/ui/src/test-utils/index.ts
@@ -7,7 +7,7 @@ export { getMockedLabel } from './mocks/mock-label';
 export { getMockedAnnotation } from './mocks/mock-annotation';
 export { getMockedProject } from './mocks/mock-project';
 export { getMockedSource } from './mocks/mock-source';
-export { getMockedModel } from './mocks/mock-model';
+export { getMockedModel, getMockedSam3Model } from './mocks/mock-model';
 export { getMockedImagesFolderSource } from './mocks/mock-images-folder-source';
 export { getMockedVideoFileSource } from './mocks/mock-video-file-source';
 export { clearMockedTauriContext, setMockedTauriContext } from './mocks/mock-tauri-context';

--- a/application/ui/src/test-utils/mocks/mock-model.ts
+++ b/application/ui/src/test-utils/mocks/mock-model.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ModelType } from '@/api';
+import type { ModelType, Sam3Model } from '@/api';
 
 export const getMockedModel = (model?: Partial<ModelType>): ModelType => {
     return {
@@ -21,6 +21,21 @@ export const getMockedModel = (model?: Partial<ModelType>): ModelType => {
         },
         active: true,
         name: 'PerDINO',
+        ...model,
+    };
+};
+
+export const getMockedSam3Model = (model?: Partial<Sam3Model>): Sam3Model => {
+    return {
+        id: 'sam3-id',
+        config: {
+            model_type: 'sam3',
+            confidence_threshold: 0.5,
+            resolution: 1008,
+            precision: 'fp32',
+        },
+        active: false,
+        name: 'SAM3',
         ...model,
     };
 };

--- a/application/ui/src/test-utils/mocks/mock-project.ts
+++ b/application/ui/src/test-utils/mocks/mock-project.ts
@@ -11,7 +11,7 @@ export const getMockedProject = (customProject: Partial<ProjectType>): ProjectTy
         name: 'animals',
         active: false,
         device: 'cpu',
-        prompt_mode: 'visual',
+        prompt_mode: 'VISUAL',
         ...customProject,
     };
 };

--- a/application/ui/tests/fixtures.ts
+++ b/application/ui/tests/fixtures.ts
@@ -71,7 +71,7 @@ const MOCK_SUPPORTED_MODELS = {
             supported_prompt_types: ['text', 'visual_rectangle'],
         },
     ],
-};
+} as const;
 const MOCK_DEFAULT_MODEL = {
     id: 'default-model-id',
     config: {
@@ -87,7 +87,7 @@ const MOCK_DEFAULT_MODEL = {
     },
     active: true,
     name: 'PerDINO',
-};
+} as const;
 
 interface Fixtures {
     network: NetworkFixture;
@@ -217,11 +217,11 @@ const test = testBase.extend<Fixtures>({
                 return HttpResponse.json({ id: promptId, ...body } as never);
             }),
             http.get('/api/v1/system/supported-models', ({ response }) => {
-                return response(200).json(MOCK_SUPPORTED_MODELS);
+                return response(200).json(MOCK_SUPPORTED_MODELS as never);
             }),
             http.get('/api/v1/projects/{project_id}/models', ({ response }) => {
                 return response(200).json({
-                    models: [MOCK_DEFAULT_MODEL],
+                    models: [MOCK_DEFAULT_MODEL as never],
                     pagination: {
                         total: 1,
                         count: 1,

--- a/application/ui/tests/fixtures.ts
+++ b/application/ui/tests/fixtures.ts
@@ -115,7 +115,7 @@ const test = testBase.extend<Fixtures>({
                             name: 'Project #1',
                             active: true,
                             device: 'cpu',
-                            prompt_mode: 'visual',
+                            prompt_mode: 'VISUAL',
                         },
                     ],
                     pagination: { total: 1, count: 1, offset: 0, limit: 10 },
@@ -127,7 +127,7 @@ const test = testBase.extend<Fixtures>({
                     name: 'Project #1',
                     active: true,
                     device: 'cpu',
-                    prompt_mode: 'visual',
+                    prompt_mode: 'VISUAL',
                 });
             }),
             http.get('/api/v1/projects/{project_id}/sources', ({ response }) => {

--- a/application/ui/tests/fixtures.ts
+++ b/application/ui/tests/fixtures.ts
@@ -216,7 +216,7 @@ const test = testBase.extend<Fixtures>({
 
                 return HttpResponse.json({ id: promptId, ...body } as never);
             }),
-            http.get('/api/v1/supported-models', ({ response }) => {
+            http.get('/api/v1/system/supported-models', ({ response }) => {
                 return response(200).json(MOCK_SUPPORTED_MODELS);
             }),
             http.get('/api/v1/projects/{project_id}/models', ({ response }) => {

--- a/application/ui/tests/fixtures.ts
+++ b/application/ui/tests/fixtures.ts
@@ -14,6 +14,81 @@ import { LabelsPage } from './labels/labels-page';
 import { ProjectPage } from './projects/projects-page';
 import { StreamPage } from './prompt/stream-page';
 
+const MOCK_SUPPORTED_MODELS = {
+    pagination: { count: 4, total: 4, offset: 0, limit: 20 },
+    models: [
+        {
+            default_config: {
+                sam_model: 'SAM-HQ-tiny',
+                encoder_model: 'dinov3_small',
+                precision: 'bf16',
+                model_type: 'matcher',
+                num_foreground_points: 5,
+                num_background_points: 3,
+                confidence_threshold: 0.38,
+                use_mask_refinement: false,
+            },
+            supported_prompt_types: ['visual_polygon'],
+        },
+        {
+            default_config: {
+                sam_model: 'SAM-HQ-tiny',
+                encoder_model: 'dinov3_small',
+                precision: 'bf16',
+                model_type: 'perdino',
+                num_foreground_points: 80,
+                num_background_points: 2,
+                num_grid_cells: 16,
+                point_selection_threshold: 0.65,
+                confidence_threshold: 0.01,
+            },
+            supported_prompt_types: ['visual_polygon'],
+        },
+        {
+            default_config: {
+                sam_model: 'SAM-HQ-tiny',
+                encoder_model: 'dinov3_small',
+                precision: 'bf16',
+                model_type: 'soft_matcher',
+                num_foreground_points: 40,
+                num_background_points: 2,
+                confidence_threshold: 0.42,
+                use_sampling: false,
+                use_spatial_sampling: false,
+                approximate_matching: false,
+                softmatching_score_threshold: 0.4,
+                softmatching_bidirectional: false,
+            },
+            supported_prompt_types: ['visual_polygon'],
+        },
+        {
+            default_config: {
+                model_type: 'sam3',
+                confidence_threshold: 0.5,
+                resolution: 1008,
+                precision: 'fp32',
+            },
+            supported_prompt_types: ['text', 'visual_rectangle'],
+        },
+    ],
+};
+const MOCK_DEFAULT_MODEL = {
+    id: 'default-model-id',
+    config: {
+        model_type: 'perdino',
+        encoder_model: 'dinov3_small',
+        sam_model: 'SAM-HQ-tiny',
+        num_foreground_points: 80,
+        num_background_points: 2,
+        num_grid_cells: 16,
+        point_selection_threshold: 0.65,
+        confidence_threshold: 0.01,
+        precision: 'bf16',
+    },
+    active: true,
+    name: 'PerDINO',
+};
+
 interface Fixtures {
     network: NetworkFixture;
     streamPage: StreamPage;
@@ -26,7 +101,6 @@ interface Fixtures {
 const test = testBase.extend<Fixtures>({
     network: createNetworkFixture({
         initialHandlers: [
-            ...handlers,
             http.get('/health', ({ response }) => {
                 return response(200).json({
                     status: 'ok',
@@ -142,17 +216,29 @@ const test = testBase.extend<Fixtures>({
 
                 return HttpResponse.json({ id: promptId, ...body } as never);
             }),
+            http.get('/api/v1/supported-models', ({ response }) => {
+                return response(200).json(MOCK_SUPPORTED_MODELS);
+            }),
             http.get('/api/v1/projects/{project_id}/models', ({ response }) => {
                 return response(200).json({
-                    models: [],
+                    models: [MOCK_DEFAULT_MODEL],
                     pagination: {
-                        total: 0,
-                        count: 0,
+                        total: 1,
+                        count: 1,
                         offset: 0,
                         limit: 10,
                     },
                 });
             }),
+            http.post('/api/v1/projects/{project_id}/models', async ({ request, response }) => {
+                const body = await request.json();
+                return response(201).json(body as never);
+            }),
+            http.put('/api/v1/projects/{project_id}/models/{model_id}', async ({ request, response }) => {
+                const body = await request.json();
+                return response(200).json(body as never);
+            }),
+            ...handlers,
         ],
     }),
     streamPage: async ({ page }, use) => {

--- a/application/ui/tests/prompt/initialize-webrtc.ts
+++ b/application/ui/tests/prompt/initialize-webrtc.ts
@@ -41,7 +41,7 @@ export const initializeWebRTC = async ({
                 name: 'Cool project',
                 active: true,
                 device: 'cpu',
-                prompt_mode: 'visual',
+                prompt_mode: 'VISUAL',
             });
         }),
 

--- a/application/ui/tests/tsconfig.json
+++ b/application/ui/tests/tsconfig.json
@@ -3,19 +3,10 @@
     "compilerOptions": {
         "baseUrl": ".",
         "paths": {
-            "@/api": [
-                "../src/api"
-            ],
-            "@/test-fixtures": [
-                "./fixtures"
-            ],
-            "@/api/*": [
-                "../src/api/*"
-            ]
+            "@/api": ["../src/api"],
+            "@/test-fixtures": ["./fixtures"],
+            "@/api/*": ["../src/api/*"]
         }
     },
-    "include": [
-        "./",
-        "../src/env.d.ts"
-    ]
+    "include": ["./", "../src/env.d.ts"]
 }

--- a/application/ui/tests/tsconfig.json
+++ b/application/ui/tests/tsconfig.json
@@ -3,9 +3,19 @@
     "compilerOptions": {
         "baseUrl": ".",
         "paths": {
-            "@/api": ["../src/api"],
-            "@/test-fixtures": ["./fixtures"]
+            "@/api": [
+                "../src/api"
+            ],
+            "@/test-fixtures": [
+                "./fixtures"
+            ],
+            "@/api/*": [
+                "../src/api/*"
+            ]
         }
     },
-    "include": ["./", "../src/env.d.ts"]
+    "include": [
+        "./",
+        "../src/env.d.ts"
+    ]
 }

--- a/application/ui/tsconfig.json
+++ b/application/ui/tsconfig.json
@@ -1,36 +1,16 @@
 {
     "extends": "@geti/config/typescript",
-    "include": [
-        "src",
-        "rsbuild.config.ts",
-        "vitest.config.ts",
-        "playwright.config.ts"
-    ],
+    "include": ["src", "rsbuild.config.ts", "vitest.config.ts", "playwright.config.ts"],
     "compilerOptions": {
-        "types": [
-            "vitest/globals",
-            "@testing-library/jest-dom"
-        ],
+        "types": ["vitest/globals", "@testing-library/jest-dom"],
         "baseUrl": ".",
         "paths": {
-            "@/test-utils": [
-                "./src/test-utils"
-            ],
-            "@/icons": [
-                "./src/assets/icons"
-            ],
-            "@/api": [
-                "./src/api"
-            ],
-            "@/hooks": [
-                "src/shared/hooks"
-            ],
-            "@/query-client": [
-                "./src/query-client/query-client"
-            ],
-            "@/api/*": [
-                "./src/api/*"
-            ]
+            "@/test-utils": ["./src/test-utils"],
+            "@/icons": ["./src/assets/icons"],
+            "@/api": ["./src/api"],
+            "@/hooks": ["src/shared/hooks"],
+            "@/query-client": ["./src/query-client/query-client"],
+            "@/api/*": ["./src/api/*"]
         }
     }
 }

--- a/application/ui/tsconfig.json
+++ b/application/ui/tsconfig.json
@@ -1,15 +1,36 @@
 {
     "extends": "@geti/config/typescript",
-    "include": ["src", "rsbuild.config.ts", "vitest.config.ts", "playwright.config.ts"],
+    "include": [
+        "src",
+        "rsbuild.config.ts",
+        "vitest.config.ts",
+        "playwright.config.ts"
+    ],
     "compilerOptions": {
-        "types": ["vitest/globals", "@testing-library/jest-dom"],
+        "types": [
+            "vitest/globals",
+            "@testing-library/jest-dom"
+        ],
         "baseUrl": ".",
         "paths": {
-            "@/test-utils": ["./src/test-utils"],
-            "@/icons": ["./src/assets/icons"],
-            "@/api": ["./src/api"],
-            "@/hooks": ["src/shared/hooks"],
-            "@/query-client": ["./src/query-client/query-client"]
+            "@/test-utils": [
+                "./src/test-utils"
+            ],
+            "@/icons": [
+                "./src/assets/icons"
+            ],
+            "@/api": [
+                "./src/api"
+            ],
+            "@/hooks": [
+                "src/shared/hooks"
+            ],
+            "@/query-client": [
+                "./src/query-client/query-client"
+            ],
+            "@/api/*": [
+                "./src/api/*"
+            ]
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR aligns prompt and model behavior across backend and UI by making prompt mode (text vs visual) a first-class part of the pipeline configuration and by filtering prompts/models based on the active model’s supported prompt/annotation types. 
On the backend, visual prompt processing is updated to operate in pixel coordinates (since neither UI nor library expect normalized coordinates) and to support both polygon masks and rectangle bounding boxes, enabling SAM3-style workflows. 
On the UI, model creation/configuration and tool selection are now driven by the backend’s “supported models” metadata instead of hardcoded assumptions.

## Changes in backend:
- Added `prompt_mode` to the pipeline config and propagated it from project state (`PipelineConfig`, `ProjectService.get_pipeline_config`).
- Updated prompt listing to respect project prompt mode and to filter visual prompts by the active processor’s supported annotation types (`PromptService.list_prompts`).
- Enabled SAM3 as a supported model and introduced utilities to derive supported annotation types from supported prompt types (`schemas/mappers/processor.get_supported_annotation_types`).
- Refactored visual prompt → training sample conversion to support:
  - polygon annotations → semantic masks,
  - rectangle annotations → bounding boxes,
  - filtering by supported annotation types, and improved grouping logic (`schemas/mappers/prompt.visual_prompt_to_sample` and helpers).
- Switched annotation coordinate handling to pixel space (removed normalization/denormalization paths) and updated mask/thumbnail generation accordingly (`polygons_to_masks`, thumbnail drawing scaling, schema examples).
- Added label ID → label name helper for correct category naming (`LabelService.get_label_names`).

## Changes in UI:
- Updated model/tool behavior to be driven by `/api/v1/system/supported-models`:
  - added `useGetSupportedModels` and `useSupportedPromptTypesMap`,
  - replaced hardcoded “annotation type for model” logic with `getAnnotationTypeFromPromptTypes`,
  - updated `ToolManager` to choose bbox vs polygon tools based on supported prompt types.
- Refactored default model creation to use backend-provided supported model metadata instead of hardcoded defaults (`useGetModels`).
- Added SAM3 support in the model configuration dialog (new SAM3 config UI + type guard `isSam3Model`) and extended related unit tests/mocks.
- Made `ModelToolbar` filter models by current prompt mode (visual vs text), and auto-select the first compatible model when switching modes; expanded toolbar tests to cover compatibility filtering.
- Improved prompt selection robustness by clearing selected prompt/frame when the selected prompt is no longer present after filtering (`VisualPromptProvider`).
- Updated test infrastructure:
  - added supported-models API mocks and ensured deterministic handler ordering (`setup-test.ts`),
  - added Playwright fixtures for supported models,
  - adjusted tsconfig path aliases (`@/api/*`).

## Type of Change

- [x] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [x] ♻️ `refactor` - Code refactoring
- [x] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

Closes #832

https://github.com/user-attachments/assets/59b5654c-93c4-4402-9b4b-03258647f837

