### PR TITLE
feat: implement DatasetWriter

### DIFF
--- a/application/backend/app/domain/services/schemas/writer.py
+++ b/application/backend/app/domain/services/schemas/writer.py
@@ -36,8 +36,8 @@ class MqttConfig(BaseModel):
 class DatasetConfig(BaseModel):
     sink_type: Literal[WriterType.DATASET] = WriterType.DATASET
     name: str = "Dataset Writer"
-    output_dir: str = "/path/to/output/dataset"
-    dataset_format: str | None = None
+    output_dir: str 
+    dataset_format: str 
     max_frames: int | None = Field(default=None, ge=1)
     export_chunk_size: int | None = Field(default=None, ge=1)
     category_mapping: dict[int, str] | None = None
@@ -49,7 +49,7 @@ class DatasetConfig(BaseModel):
                 "sink_type": "dataset",
                 "name": "Dataset Writer",
                 "output_dir": "/path/to/output/dataset",
-                "dataset_format": None,
+                "dataset_format": "COCO",
                 "max_frames": None,
                 "export_chunk_size": None,
                 "category_mapping": None,

--- a/application/backend/app/domain/services/schemas/writer.py
+++ b/application/backend/app/domain/services/schemas/writer.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 class WriterType(StrEnum):
     MQTT = "mqtt"
+    DATASET = "dataset"
 
 
 class MqttConfig(BaseModel):
@@ -32,5 +33,29 @@ class MqttConfig(BaseModel):
         }
     }
 
+class DatasetConfig(BaseModel):
+    sink_type: Literal[WriterType.DATASET] = WriterType.DATASET
+    name: str = "Dataset Writer"
+    output_dir: str = "/path/to/output/dataset"
+    dataset_format: str | None = None
+    max_frames: int | None = Field(default=None, ge=1)
+    export_chunk_size: int | None = Field(default=None, ge=1)
+    category_mapping: dict[int, str] | None = None
+    frame_trace: bool = False
 
-WriterConfig = Annotated[MqttConfig, Field(discriminator="sink_type")]
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "sink_type": "dataset",
+                "name": "Dataset Writer",
+                "output_dir": "/path/to/output/dataset",
+                "dataset_format": None,
+                "max_frames": None,
+                "export_chunk_size": None,
+                "category_mapping": None,
+                "frame_trace": False
+            }
+        }
+    }
+
+WriterConfig = Annotated[MqttConfig | DatasetConfig, Field(discriminator="sink_type")]

--- a/application/backend/app/runtime/core/components/factories/writer.py
+++ b/application/backend/app/runtime/core/components/factories/writer.py
@@ -6,7 +6,6 @@ import os
 from domain.services.schemas.writer import DatasetConfig, MqttConfig, WriterConfig
 from runtime.core.components.base import StreamWriter
 from runtime.core.components.writers.mqtt_writer import MqttWriter
-from runtime.core.components.writers.dataset_writer import DatasetWriter
 from runtime.core.components.writers.noop_writer import NoOpWriter
 
 
@@ -29,6 +28,12 @@ class StreamWriterFactory:
                     password=os.getenv("MQTT_PASSWORD", "password"),
                 )
             case DatasetConfig() as config:
+                try:
+                    from runtime.core.components.writers.dataset_writer import DatasetWriter
+                except ImportError as e:
+                    raise RuntimeError(
+                        "Requires datumaro. Install with: uv sync --extra dataset"
+                    ) from e
                 return DatasetWriter(config=config)
             case _:
                 return NoOpWriter()

--- a/application/backend/app/runtime/core/components/factories/writer.py
+++ b/application/backend/app/runtime/core/components/factories/writer.py
@@ -3,9 +3,10 @@
 
 import os
 
-from domain.services.schemas.writer import MqttConfig, WriterConfig
+from domain.services.schemas.writer import DatasetConfig, MqttConfig, WriterConfig
 from runtime.core.components.base import StreamWriter
 from runtime.core.components.writers.mqtt_writer import MqttWriter
+from runtime.core.components.writers.dataset_writer import DatasetWriter
 from runtime.core.components.writers.noop_writer import NoOpWriter
 
 
@@ -27,5 +28,7 @@ class StreamWriterFactory:
                     username=os.getenv("MQTT_USERNAME", "username"),
                     password=os.getenv("MQTT_PASSWORD", "password"),
                 )
+            case DatasetConfig() as config:
+                return DatasetWriter(config=config)
             case _:
                 return NoOpWriter()

--- a/application/backend/app/runtime/core/components/writers/dataset_writer.py
+++ b/application/backend/app/runtime/core/components/writers/dataset_writer.py
@@ -18,11 +18,19 @@ class DatasetWriter(StreamWriter):
         self._buffered_frame_count: int = 0
         self._chunk_index: int = 0
         self._chunk_size: int | None = config.export_chunk_size
-        self._export_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="dataset-export")  #TODO: consider making this configurable so multiple chunks can export in parallel when disk I/O is slow.
+
+        # TODO: Consider making this configurable so multiple chunks can
+        # export in parallel when disk I/O is slow.
+        self._export_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="dataset-export",
+        )
         self._export_futures: list[Future[None]] = []
 
-        if self._chunk_size is not None and not self._config.dataset_format:
-            raise ValueError("dataset_format must be set when export_chunk_size is configured")
+        if self._config.dataset_format is None:
+            raise ValueError("dataset_format must be set")
+        if self._config.output_dir is None:
+            raise ValueError("output_dir must be set")
         self._dataset = Dataset()
         logger.info("DatasetWriter ready. Dataset format: %s, Output dir: %s", self._config.dataset_format, self._config.output_dir)
 
@@ -87,11 +95,11 @@ class DatasetWriter(StreamWriter):
 
         Handles Detection, Segmentation, and Point predictions based on the presence of keys:
 
-            pred_masks  (Tensor): Segmentation masks, shape [N, H, W].
-            pred_points (Tensor): Point predictions, shape [N, 4] as [x, y, score, fg_label].
-            pred_boxes  (Tensor): Bounding boxes, shape [N, 5] as [x1, y1, x2, y2, score].
-            pred_labels (Tensor): Class indices, shape [N].
-            pred_scores (Tensor): Confidence scores, shape [N].
+            pred_masks  : Segmentation masks, shape [N, H, W].
+            pred_points : Point predictions, shape [N, 4] as [x, y, score, fg_label].
+            pred_boxes  : Bounding boxes, shape [N, 5] as [x1, y1, x2, y2, score].
+            pred_labels : Class indices, shape [N].
+            pred_scores : Confidence scores, shape [N].
 
         Args:
             data: OutputData containing frame and model predictions.
@@ -103,7 +111,6 @@ class DatasetWriter(StreamWriter):
 
         if self._config.max_frames is not None and self._frame_count >= self._config.max_frames:
             return
-
         if not data.results:
             raise ValueError("OutputData.results is empty")
 
@@ -112,14 +119,11 @@ class DatasetWriter(StreamWriter):
             if pred_labels is None:
                 raise ValueError("OutputData result is missing 'pred_labels'")
             annotations = []
-            
             # Determine number of instances from pred_labels
-            num_instances = len(pred_labels) 
-            
+            num_instances = len(pred_labels)
             # Process each instance
             for i in range(num_instances):
-                label_id = int(pred_labels[i]) 
-                
+                label_id = int(pred_labels[i])
                 # Add mask if available
                 if "pred_masks" in result:
                     mask = result["pred_masks"][i]
@@ -130,7 +134,6 @@ class DatasetWriter(StreamWriter):
                             attributes={"score": float(result["pred_scores"][i])} if "pred_scores" in result else None,
                         )
                     )
-                   
                 # Add bbox if available
                 if "pred_boxes" in result:
                     x1, y1, x2, y2, score = result["pred_boxes"][i].tolist()
@@ -142,7 +145,6 @@ class DatasetWriter(StreamWriter):
                             attributes={"score": score},
                         )
                     )
-                
                 # Add points if available
                 if "pred_points" in result:
                     x, y, score, fg_label = result["pred_points"][i].tolist()
@@ -154,9 +156,7 @@ class DatasetWriter(StreamWriter):
                         )
                     )
 
-
             item_id = f"frame_{self._frame_count:06d}"
-
             attributes = {}
             if self._config.frame_trace and data.trace:
                 attributes["trace_id"] = data.trace.frame_id
@@ -170,13 +170,13 @@ class DatasetWriter(StreamWriter):
                 attributes=attributes or None,
             )
             self._dataset.put(item)
-            self._frame_count += 1
-            self._buffered_frame_count += 1
             logger.debug(
                 "Frame %d buffered. Objects: %d",
                 self._frame_count,
                 num_instances,
             )
+            self._frame_count += 1
+            self._buffered_frame_count += 1
             self._flush_chunk_if_needed()
 
     def _export(

--- a/application/backend/app/runtime/core/components/writers/dataset_writer.py
+++ b/application/backend/app/runtime/core/components/writers/dataset_writer.py
@@ -1,0 +1,240 @@
+import logging
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+
+from datumaro import Dataset, DatasetItem, Image
+from datumaro.components.annotation import Bbox, Mask, Points
+
+from domain.services.schemas.processor import OutputData
+from domain.services.schemas.writer import DatasetConfig
+from runtime.core.components.base import StreamWriter
+
+logger = logging.getLogger(__name__)
+
+class DatasetWriter(StreamWriter):
+    def __init__(self, config: DatasetConfig) -> None:
+        self._config = config
+        self._frame_count: int = 0
+        self._buffered_frame_count: int = 0
+        self._chunk_index: int = 0
+        self._chunk_size: int | None = config.export_chunk_size
+        self._export_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="dataset-export")  #TODO: consider making this configurable so multiple chunks can export in parallel when disk I/O is slow.
+        self._export_futures: list[Future[None]] = []
+
+        if self._chunk_size is not None and not self._config.dataset_format:
+            raise ValueError("dataset_format must be set when export_chunk_size is configured")
+        self._dataset = Dataset()
+        logger.info("DatasetWriter ready. Dataset format: %s, Output dir: %s", self._config.dataset_format, self._config.output_dir)
+
+    def _get_export_dir(self) -> Path:
+        output_dir = Path(self._config.output_dir)
+        if self._chunk_size is None:
+            return output_dir
+        return output_dir / f"batch_{self._chunk_index:04d}"
+
+    def _reset_buffer(self) -> None:
+        self._dataset = Dataset()
+        self._buffered_frame_count = 0
+
+    def _flush_chunk_if_needed(self) -> None:
+        if self._chunk_size is None:
+            return
+        if self._buffered_frame_count < self._chunk_size:
+            return
+        self._queue_export(
+            dataset=self._dataset,
+            output_dir=self._get_export_dir(),
+            buffered_frame_count=self._buffered_frame_count,
+            total_frame_count=self._frame_count,
+        )
+        self._chunk_index += 1
+        self._reset_buffer()
+
+    def _queue_export(
+        self,
+        dataset: Dataset,
+        output_dir: Path,
+        buffered_frame_count: int,
+        total_frame_count: int,
+    ) -> None:
+        future = self._export_executor.submit(
+            self._export,
+            dataset,
+            output_dir,
+            buffered_frame_count,
+            total_frame_count,
+        )
+        self._export_futures.append(future)
+
+    def _drain_export_futures(self, wait: bool) -> None:
+        pending_futures: list[Future[None]] = []
+        for future in self._export_futures:
+            if wait or future.done():
+                future.result()
+            else:
+                pending_futures.append(future)
+        self._export_futures = pending_futures
+
+    def connect(self) -> None:
+        # No connection needed for dataset writer
+        pass
+
+    def write(self, data: OutputData) -> None:
+        """Buffer a single pipeline output into the Dataset.
+
+        Processes OutputData.results which is list[dict[str, np.ndarray]]
+        where each dict contains predictions for a single image.
+
+        Handles Detection, Segmentation, and Point predictions based on the presence of keys:
+
+            pred_masks  (Tensor): Segmentation masks, shape [N, H, W].
+            pred_points (Tensor): Point predictions, shape [N, 4] as [x, y, score, fg_label].
+            pred_boxes  (Tensor): Bounding boxes, shape [N, 5] as [x1, y1, x2, y2, score].
+            pred_labels (Tensor): Class indices, shape [N].
+            pred_scores (Tensor): Confidence scores, shape [N].
+
+        Args:
+            data: OutputData containing frame and model predictions.
+
+        Raises:
+            ValueError: If OutputData.results is empty or not in expected format.
+        """
+        self._drain_export_futures(wait=False)
+
+        if self._config.max_frames is not None and self._frame_count >= self._config.max_frames:
+            return
+
+        if not data.results:
+            raise ValueError("OutputData.results is empty")
+
+        for result in data.results:
+            pred_labels = result.get("pred_labels")
+            if pred_labels is None:
+                raise ValueError("OutputData result is missing 'pred_labels'")
+            annotations = []
+            
+            # Determine number of instances from pred_labels
+            num_instances = len(pred_labels) 
+            
+            # Process each instance
+            for i in range(num_instances):
+                label_id = int(pred_labels[i]) 
+                
+                # Add mask if available
+                if "pred_masks" in result:
+                    mask = result["pred_masks"][i]
+                    annotations.append(
+                        Mask(
+                            image=mask,
+                            label=label_id,
+                            attributes={"score": float(result["pred_scores"][i])} if "pred_scores" in result else None,
+                        )
+                    )
+                   
+                # Add bbox if available
+                if "pred_boxes" in result:
+                    x1, y1, x2, y2, score = result["pred_boxes"][i].tolist()
+                    annotations.append(
+                        Bbox(
+                            x=x1, y=y1,
+                            w=x2 - x1, h=y2 - y1,
+                            label=label_id,
+                            attributes={"score": score},
+                        )
+                    )
+                
+                # Add points if available
+                if "pred_points" in result:
+                    x, y, score, fg_label = result["pred_points"][i].tolist()
+                    annotations.append(
+                        Points(
+                            points=[(x, y)],
+                            label=label_id,
+                            attributes={"score": score, "fg_label": fg_label},
+                        )
+                    )
+
+
+            item_id = f"frame_{self._frame_count:06d}"
+
+            attributes = {}
+            if self._config.frame_trace and data.trace:
+                attributes["trace_id"] = data.trace.frame_id
+            if self._config.category_mapping is not None:
+                attributes["category_mapping"] = self._config.category_mapping
+
+            item = DatasetItem(
+                id=item_id,
+                image=Image.from_numpy(data.frame),
+                annotations=annotations,
+                attributes=attributes or None,
+            )
+            self._dataset.put(item)
+            self._frame_count += 1
+            self._buffered_frame_count += 1
+            logger.debug(
+                "Frame %d buffered. Objects: %d",
+                self._frame_count,
+                num_instances,
+            )
+            self._flush_chunk_if_needed()
+
+    def _export(
+        self,
+        dataset: Dataset,
+        output_dir: Path,
+        buffered_frame_count: int,
+        total_frame_count: int,
+    ) -> None:
+        """Serialize a Dataset snapshot to disk.
+
+        Raises:
+            ValueError: If dataset_format is not provided or not supported.
+            RuntimeError: If no frames have been captured.
+        """
+        fmt = self._config.dataset_format
+
+        if not fmt:
+            raise ValueError("dataset_format is not provided")
+
+        if buffered_frame_count == 0:
+            raise RuntimeError("No frames captured. Nothing to export.")
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            dataset.export(str(output_dir), format=fmt, save_media=True)
+        except Exception as e:
+            logger.error("Error occurred while exporting dataset: %s", e)
+            raise ValueError(f"Failed to export dataset with format '{fmt}': {e}") from e
+        logger.info(
+            "Dataset exported to %s in %s format. Buffered frames: %d. Total frames: %d",
+            output_dir, fmt, buffered_frame_count, total_frame_count,
+        )
+
+    def close(self) -> None:
+        """Export the remaining buffer if configured, then release in-memory state."""
+        released_frames = self._buffered_frame_count
+        try:
+            if self._buffered_frame_count > 0 and self._config.dataset_format:
+                self._queue_export(
+                    dataset=self._dataset,
+                    output_dir=self._get_export_dir(),
+                    buffered_frame_count=self._buffered_frame_count,
+                    total_frame_count=self._frame_count,
+                )
+                if self._chunk_size is not None:
+                    self._chunk_index += 1
+            elif self._buffered_frame_count > 0:
+                logger.warning(
+                    "Skipping export during close because dataset_format is not set. Buffered frames: %d",
+                    self._buffered_frame_count,
+                )
+            self._drain_export_futures(wait=True)
+        finally:
+            self._export_executor.shutdown(wait=True)
+            self._reset_buffer()
+            self._frame_count = 0
+            self._chunk_index = 0
+            logger.info("DatasetWriter closed. Released buffered frames: %d", released_frames)
+
+

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -47,6 +47,10 @@ mqtt = [
     "paho-mqtt~=2.1.0",
 ]
 
+dataset = [
+    "datumaro~=1.12.0"
+]
+
 [tool.uv]
 default-groups = ["dev"]
 required-version = "~=0.10.0"


### PR DESCRIPTION
# Pull Request

## Description
Adds a new dataset writer using Datumaro so inference results can be exported as datasets. Predictions are buffered in-memory as Datumaro `DatasetItem`s and exported to disk in the specified format (e.g. COCO) using background worker.

This PR includes:
1. `DatasetWriter` implementation (`application/backend/app/runtime/core/components/writers/dataset_writer.py`)
2. `DatasetConfig` schema (`application/backend/app/domain/services/schemas/writer.py`)
3. Registered `DatasetWriter` in the writer factory (`application/backend/app/runtime/core/components/factories/writer.py`)
4. Added Datumaro to extra dataset dependencies (`application/backend/pyproject.toml`)
## Type of Change

- [x] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

Related: GSoC 2026 - Auto-Labeling “Data Factory” & Edge Training Integration (Project 27)

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

## Before/After Comparison (4 Commits)

| Commit | Scope | Before | After |
|---|---|---|---|
| d1c424a | Implement `DatasetWriter` | No dataset writer existed. Pipeline outputs could not be persisted as a local dataset via a dedicated writer path. | Added `DatasetWriter` at  `application/backend/app/runtime/core/components/writers/dataset_writer.py` with `Datumaro` conversion for masks/bboxes/points, buffered frame ingestion, optional chunked exports,  export queue, trace/category metadata handling, and close-time flush/export behavior. |
| a4ab507 | Add `Datumaro` dependency | No backend optional dependency group for dataset export. `Datumaro` was not declared as an optional install target. | Added dataset optional dependency group in `application/backend/pyproject.toml` with `datumaro~=1.12.0`. |
| f1a10f5 | Add `DatasetConfig` schema | `WriterType` only supported `"mqtt"`. `WriterConfig` union only accepted `MqttConfig`. No schema for dataset writer configuration. | Added `WriterType` `"dataset"`, introduced `DatasetConfig` (output_dir, dataset_format, max_frames, export_chunk_size, category_mapping, frame_trace, etc.), and expanded `WriterConfig` discriminator union to include both `MqttConfig` and `DatasetConfig`. |
| e64a449 | Register `DatasetWriter` in factory | `StreamWriterFactory` handled `MqttConfig` and otherwise fell back to `NoOpWriter`. Dataset writer could not be created from config. | Updated factory to import `DatasetConfig` and `DatasetWriter` and route `DatasetConfig` to `DatasetWriter(config=config)`, wiring dataset writer into runtime writer creation. |


## Screenshots

<!-- UI changes or visual demos -->
