### PR TITLE
fix: resolve manual workflow dispatch failures and refactor image tags

### DIFF
--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -11,10 +11,15 @@ on:
         description: "Specifies the build version to apply to all binaries produced by this workflow"
         type: string
         required: true
-      image_name_prefix:
-        description: "Base name for the docker images (without tag)"
+      container_registry:
+        description: "Container registry for the docker images"
         type: string
-        default: "ghcr.io/open-edge-platform/instant-learn-dev"
+        default: "ghcr.io/open-edge-platform"
+        required: false
+      image_tag_suffix:
+        description: "Suffix to append to the image tag (e.g. -dev, -nightly)"
+        type: string
+        default: "-dev"
         required: false
       push_images:
         description: "Push and sign docker images to GHCR"
@@ -37,6 +42,16 @@ on:
         description: "Specifies the build version to apply to all binaries produced by this workflow"
         type: string
         required: true
+      container_registry:
+        description: "Container registry for the docker images"
+        type: string
+        default: "ghcr.io/open-edge-platform"
+        required: false
+      image_tag_suffix:
+        description: "Suffix to append to the image tag (e.g. -dev, -nightly)"
+        type: string
+        default: "-dev"
+        required: false
 
 permissions: {} # No permissions by default
 
@@ -55,8 +70,14 @@ jobs:
     env:
       BUILD_VERSION: ${{ inputs.build_version }}
       DEVICE: ${{ matrix.ai-device }}
-      IMAGE_NAME_PREFIX: ${{ inputs.image_name_prefix }}
+      CONTAINER_REGISTRY: ${{ inputs.container_registry }}
+      IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
     steps:
+      - name: Construct image name
+        run: |
+          IMAGE_NAME="${CONTAINER_REGISTRY}/instant-learn-${DEVICE}:${BUILD_VERSION}${IMAGE_TAG_SUFFIX}"
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> "$GITHUB_ENV"
+
       - name: Validate SHA format
         if: inputs.sha-commit != ''
         env:
@@ -85,7 +106,7 @@ jobs:
           just \
             build-target="${DEVICE}" \
             version="${BUILD_VERSION}" \
-            image-name="${IMAGE_NAME_PREFIX}-${DEVICE}:${BUILD_VERSION}" \
+            image-name="${IMAGE_NAME}" \
             docker-build-context="--no-cache" \
             build-image
 
@@ -95,7 +116,7 @@ jobs:
           just \
             build-target="${DEVICE}" \
             version="${BUILD_VERSION}" \
-            image-name="${IMAGE_NAME_PREFIX}-${DEVICE}:${BUILD_VERSION}" \
+            image-name="${IMAGE_NAME}" \
             show-size
 
       - name: Test image for ${{ matrix.ai-device }}
@@ -104,7 +125,7 @@ jobs:
           just \
             build-target="${DEVICE}" \
             version="${BUILD_VERSION}" \
-            image-name="${IMAGE_NAME_PREFIX}-${DEVICE}:${BUILD_VERSION}" \
+            image-name="${IMAGE_NAME}" \
             test-image
 
       - name: Log in to GHCR
@@ -117,10 +138,9 @@ jobs:
 
       - name: Tag and push image for ${{ matrix.ai-device }}
         if: inputs.push_images
+        working-directory: application
         run: |
-          IMAGE_NAME="${IMAGE_NAME_PREFIX}-${DEVICE}:${BUILD_VERSION}"
           docker push "${IMAGE_NAME}"
-          echo "IMAGE_NAME=${IMAGE_NAME}" >> "$GITHUB_ENV"
 
       - name: Sign image for ${{ matrix.ai-device }}
         if: inputs.push_images

--- a/.github/workflows/distrib.yml
+++ b/.github/workflows/distrib.yml
@@ -19,7 +19,7 @@ on:
       image_tag_suffix:
         description: "Suffix to append to the image tag (e.g. -dev, -nightly)"
         type: string
-        default: "-dev"
+        default: ""
         required: false
       push_images:
         description: "Push and sign docker images to GHCR"

--- a/.github/workflows/release-candidate-app.yml
+++ b/.github/workflows/release-candidate-app.yml
@@ -58,7 +58,6 @@ jobs:
       ai_devices: '["xpu"]'
       build_version: ${{ needs.build-parameters.outputs.build_version }}
       push_images: true
-      image_name_prefix: "ghcr.io/open-edge-platform/geti-instant-learn"
 
   windows-installer:
     name: Build Windows installer


### PR DESCRIPTION
## Description

This PR fixes an issue where triggering the distrib workflow manually would fail due to an invalid docker image name.

Changes made:

- Resolves the missing input parameters that caused empty string evaluation during workflow_dispatch.
- Replaces the generic `component_name` input with a specific image_tag_suffix (e.g., -dev, -nightly) to correctly append designations to the version tag instead of the component name.
- Dynamically constructs the IMAGE_NAME as an environment variable in a single workflow step to guarantee consistency across the build-image, test-image, and docker push steps.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

Fixes #917 