### PR TITLE
fix: resolve GPU OOM in SAM decoder

### DIFF
--- a/library/src/instantlearn/components/sam/decoder.py
+++ b/library/src/instantlearn/components/sam/decoder.py
@@ -8,10 +8,15 @@ from torch import nn
 from torch.nn import functional
 
 from instantlearn.components.sam.predictor import SAMPredictor
+from instantlearn.utils.image_resize import downscale_image, upscale_masks
 
 
 def masks_to_boxes_traceable(masks: torch.Tensor) -> torch.Tensor:
     """Traceable version of masks_to_boxes that works with ONNX export.
+
+    Projects masks onto row/column axes first, then finds min/max coordinates
+    on 1D vectors. This avoids materializing NxHxW coordinate grids, reducing
+    intermediate memory from O(N*H*W) to O(N*H + N*W).
 
     Args:
         masks: Tensor[N, H, W] - binary masks
@@ -19,33 +24,30 @@ def masks_to_boxes_traceable(masks: torch.Tensor) -> torch.Tensor:
     Returns:
         Tensor[N, 4] - bounding boxes in (x1, y1, x2, y2) format
     """
-    # Handle empty masks by clamping to at least 1 element to avoid conditionals
-    # The caller should check for empty masks separately
-    n = masks.size(0)
     h = masks.size(1)
     w = masks.size(2)
 
-    # Create coordinate grids [N, H, W]
-    y_coords = torch.arange(h, device=masks.device, dtype=torch.float).view(1, h, 1).expand(n, h, w)
-    x_coords = torch.arange(w, device=masks.device, dtype=torch.float).view(1, 1, w).expand(n, h, w)
+    # Project masks onto axes: [N, H, W] -> [N, W] and [N, H]
+    # This collapses one spatial dimension first, so subsequent ops are cheap.
+    any_per_col = masks.any(dim=1)  # [N, W] -- True if column has any mask pixel
+    any_per_row = masks.any(dim=2)  # [N, H] -- True if row has any mask pixel
 
-    # Boolean mask
-    mask_bool = masks.bool()
+    # 1D coordinate vectors (NOT expanded to NxHxW)
+    x_coords = torch.arange(w, device=masks.device, dtype=torch.float)  # [W]
+    y_coords = torch.arange(h, device=masks.device, dtype=torch.float)  # [H]
 
-    # Use large/small sentinel values for min/max reduction
     large_val = torch.tensor(max(h, w) + 1, dtype=torch.float, device=masks.device)
 
-    # For min: non-mask pixels get large value, for max: get -1
-    x_for_min = torch.where(mask_bool, x_coords, large_val)
-    x_for_max = torch.where(mask_bool, x_coords, -1.0)
-    y_for_min = torch.where(mask_bool, y_coords, large_val)
-    y_for_max = torch.where(mask_bool, y_coords, -1.0)
+    # Sentinel-based min/max on projected 1D vectors: [N, W] and [N, H]
+    x_for_min = torch.where(any_per_col, x_coords.unsqueeze(0), large_val)  # [N, W]
+    x_for_max = torch.where(any_per_col, x_coords.unsqueeze(0), -1.0)  # [N, W]
+    y_for_min = torch.where(any_per_row, y_coords.unsqueeze(0), large_val)  # [N, H]
+    y_for_max = torch.where(any_per_row, y_coords.unsqueeze(0), -1.0)  # [N, H]
 
-    # Flatten spatial dims and reduce
-    x1 = x_for_min.flatten(1).min(dim=1).values
-    y1 = y_for_min.flatten(1).min(dim=1).values
-    x2 = x_for_max.flatten(1).max(dim=1).values
-    y2 = y_for_max.flatten(1).max(dim=1).values
+    x1 = x_for_min.min(dim=1).values
+    y1 = y_for_min.min(dim=1).values
+    x2 = x_for_max.max(dim=1).values
+    y2 = y_for_max.max(dim=1).values
 
     return torch.stack([x1, y1, x2, y2], dim=1)
 
@@ -62,6 +64,10 @@ class SamDecoder(nn.Module):
             in the final output. Higher values = stricter filtering. Default: 0.38.
         max_masks_per_category: Maximum masks to return per category (for padding). Default: 40.
         use_mask_refinement: Whether to use 2-stage mask refinement with box prompts. Default: False.
+        max_image_side: Maximum image side length for SAM processing. Images larger than
+            this are downscaled (preserving aspect ratio) before SAM, then masks are
+            upscaled back. SAM works internally at 1024x1024, so larger images just
+            increase mask memory without improving quality. Default: 1024.
     """
 
     def __init__(
@@ -70,6 +76,7 @@ class SamDecoder(nn.Module):
         confidence_threshold: float = 0.38,
         max_masks_per_category: int = 40,
         use_mask_refinement: bool = False,
+        max_image_side: int = 1024,
     ) -> None:
         """Initialize the traceable SAM decoder."""
         super().__init__()
@@ -77,6 +84,7 @@ class SamDecoder(nn.Module):
         self.confidence_threshold = confidence_threshold
         self.max_masks_per_category = max_masks_per_category
         self.use_mask_refinement = use_mask_refinement
+        self.max_image_side = max_image_side
         self.device = sam_predictor.device
 
     def _preprocess_points(self, points: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # noqa: PLR6301
@@ -275,19 +283,41 @@ class SamDecoder(nn.Module):
             category_ids: Category ID mapping [C]
 
         Returns:
-            pred_masks: [num_valid_masks, H, W]
+            pred_masks: [num_valid_masks, orig_H, orig_W]
             pred_scores: [num_valid_masks]
             pred_labels: [num_valid_masks]
-            pred_points: [num_points_used, 4]
+            pred_points: [num_points_used, 4] (in original image coordinates)
         """
-        h, w = image.size(1), image.size(2)
-        orig_size = (h, w)
+        orig_h, orig_w = image.size(1), image.size(2)
+        orig_size = (orig_h, orig_w)
+
+        # Downscale large images to limit GPU memory.
+        # SAM internally encodes at 1024x1024 so larger output masks just
+        # upsample SAM's 256x256 logits without improving quality.
+        downscaled = downscale_image(image, self.max_image_side)
+        image = downscaled.image
+        scale = downscaled.scale
+
+        if downscaled.is_scaled:
+            point_prompts = point_prompts.clone()
+            point_prompts[..., 0] *= scale  # x
+            point_prompts[..., 1] *= scale  # y
+
+        work_h, work_w = image.size(1), image.size(2)
+        work_size = (work_h, work_w)
         self.predictor.set_image(image)
 
         num_categories = category_ids.shape[0] if hasattr(category_ids, "shape") else len(category_ids)
         device = self.device
 
-        all_masks = torch.zeros(num_categories, self.max_masks_per_category, h, w, device=device)
+        all_masks = torch.zeros(
+            num_categories,
+            self.max_masks_per_category,
+            work_h,
+            work_w,
+            device=device,
+            dtype=torch.bool,
+        )
         all_scores = torch.zeros(num_categories, self.max_masks_per_category, device=device)
         all_labels = torch.full((num_categories, self.max_masks_per_category), -1, device=device, dtype=torch.int64)
         used_points_list: list[torch.Tensor] = []
@@ -302,14 +332,14 @@ class SamDecoder(nn.Module):
                 point_coords,
                 point_labels,
                 similarity,
-                orig_size,
+                work_size,
             )
 
             padded_masks, padded_scores, padded_labels = self._pad_outputs(
                 masks,
                 scores,
                 class_id,
-                orig_size,
+                work_size,
             )
 
             all_masks[class_idx] = padded_masks
@@ -323,10 +353,18 @@ class SamDecoder(nn.Module):
 
         # Flatten and filter valid predictions
         valid_mask = all_labels >= 0
-        pred_masks = all_masks.bool()[valid_mask]
+        pred_masks = all_masks[valid_mask]
         pred_scores = all_scores[valid_mask]
         pred_labels = all_labels[valid_mask]
         pred_points = torch.cat(used_points_list, dim=0)
+
+        # Upscale masks and points back to original resolution
+        if downscaled.is_scaled:
+            pred_masks = upscale_masks(pred_masks, orig_size)
+            if pred_points.numel() > 0:
+                pred_points = pred_points.clone()
+                pred_points[:, 0] /= scale  # x
+                pred_points[:, 1] /= scale  # y
 
         return pred_masks, pred_scores, pred_labels, pred_points
 

--- a/library/src/instantlearn/utils/image_resize.py
+++ b/library/src/instantlearn/utils/image_resize.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility functions for aspect-ratio-preserving image and mask resizing."""
+
+from dataclasses import dataclass
+
+import torch
+from torch.nn import functional
+
+
+@dataclass
+class DownscaleResult:
+    """Result of downscaling an image, with metadata needed to reverse the operation.
+
+    Attributes:
+        image: The (possibly) downscaled image [C, H', W'].
+        scale: Scale factor applied (1.0 if no downscaling needed).
+        orig_size: Original (H, W) before downscaling.
+    """
+
+    image: torch.Tensor
+    scale: float
+    orig_size: tuple[int, int]
+
+    @property
+    def is_scaled(self) -> bool:
+        """Whether the image was actually downscaled."""
+        return self.scale < 1.0
+
+
+def downscale_image(image: torch.Tensor, max_side: int) -> DownscaleResult:
+    """Downscale an image so its longest side does not exceed max_side.
+
+    Preserves aspect ratio. Returns the image unchanged if already small enough.
+
+    Args:
+        image: Image tensor [C, H, W] (any dtype).
+        max_side: Maximum allowed side length.
+
+    Returns:
+        DownscaleResult with the image, scale factor, and original size.
+    """
+    h, w = image.size(1), image.size(2)
+    longest = max(h, w)
+
+    if longest <= max_side:
+        return DownscaleResult(image=image, scale=1.0, orig_size=(h, w))
+
+    scale = max_side / longest
+    new_h = int(h * scale)
+    new_w = int(w * scale)
+    resized = (
+        functional.interpolate(
+            image.unsqueeze(0).float(),
+            size=(new_h, new_w),
+            mode="bilinear",
+            align_corners=False,
+        )
+        .squeeze(0)
+        .to(image.dtype)
+    )
+    return DownscaleResult(image=resized, scale=scale, orig_size=(h, w))
+
+
+def upscale_masks(masks: torch.Tensor, orig_size: tuple[int, int]) -> torch.Tensor:
+    """Upscale boolean masks back to their original resolution.
+
+    Uses nearest-neighbor interpolation to preserve sharp mask boundaries.
+
+    Args:
+        masks: Boolean masks [N, H', W'] at reduced resolution.
+        orig_size: Target (H, W) to restore.
+
+    Returns:
+        Masks [N, H, W] at original resolution.
+    """
+    if masks.numel() == 0:
+        return masks
+    return (
+        functional.interpolate(
+            masks.unsqueeze(1).float(),
+            size=orig_size,
+            mode="nearest",
+        )
+        .squeeze(1)
+        .bool()
+    )

--- a/library/tests/unit/utils/test_image_resize.py
+++ b/library/tests/unit/utils/test_image_resize.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for image and mask resizing utilities."""
+
+import pytest
+import torch
+
+from instantlearn.utils.image_resize import DownscaleResult, downscale_image, upscale_masks
+
+
+class TestDownscaleImage:
+    def test_no_downscale_when_within_limit(self) -> None:
+        """Image smaller than max_side is returned unchanged."""
+        image = torch.randn(3, 512, 768)
+        result = downscale_image(image, max_side=1024)
+
+        assert result.image is image
+        assert result.scale == 1.0
+        assert result.orig_size == (512, 768)
+        assert not result.is_scaled
+
+    def test_no_downscale_when_equal_to_limit(self) -> None:
+        """Image exactly at max_side is returned unchanged."""
+        image = torch.randn(3, 1024, 800)
+        result = downscale_image(image, max_side=1024)
+
+        assert result.image is image
+        assert result.scale == 1.0
+        assert not result.is_scaled
+
+    def test_downscale_landscape(self) -> None:
+        """Landscape image is downscaled based on width."""
+        image = torch.randn(3, 1000, 2000)
+        result = downscale_image(image, max_side=1000)
+
+        assert result.is_scaled
+        assert result.scale == pytest.approx(0.5)
+        assert result.orig_size == (1000, 2000)
+        assert result.image.shape == (3, 500, 1000)
+
+    def test_downscale_portrait(self) -> None:
+        """Portrait image is downscaled based on height."""
+        image = torch.randn(3, 2000, 1000)
+        result = downscale_image(image, max_side=1000)
+
+        assert result.is_scaled
+        assert result.scale == pytest.approx(0.5)
+        assert result.image.shape == (3, 1000, 500)
+
+    def test_downscale_preserves_aspect_ratio(self) -> None:
+        """Aspect ratio is preserved after downscaling."""
+        image = torch.randn(3, 2776, 2082)
+        result = downscale_image(image, max_side=1024)
+
+        original_ratio = 2082 / 2776
+        new_h, new_w = result.image.shape[1], result.image.shape[2]
+        new_ratio = new_w / new_h
+
+        assert new_ratio == pytest.approx(original_ratio, abs=0.01)
+
+    def test_downscale_preserves_dtype(self) -> None:
+        """Output tensor dtype matches input dtype."""
+        for dtype in [torch.float32, torch.bfloat16, torch.uint8]:
+            image = torch.zeros(3, 2048, 2048, dtype=dtype)
+            result = downscale_image(image, max_side=1024)
+            assert result.image.dtype == dtype
+
+    def test_downscale_longest_side_within_limit(self) -> None:
+        """Downscaled image longest side does not exceed max_side."""
+        image = torch.randn(3, 3000, 4000)
+        result = downscale_image(image, max_side=1024)
+
+        assert max(result.image.shape[1], result.image.shape[2]) <= 1024
+
+
+class TestUpscaleMasks:
+    def test_upscale_to_original_size(self) -> None:
+        """Masks are upscaled to the requested size."""
+        masks = torch.ones(5, 50, 100, dtype=torch.bool)
+        result = upscale_masks(masks, orig_size=(200, 400))
+
+        assert result.shape == (5, 200, 400)
+        assert result.dtype == torch.bool
+
+    def test_upscale_preserves_true_values(self) -> None:
+        """All-true masks remain all-true after upscale."""
+        masks = torch.ones(2, 64, 64, dtype=torch.bool)
+        result = upscale_masks(masks, orig_size=(256, 256))
+
+        assert result.all()
+
+    def test_upscale_preserves_false_values(self) -> None:
+        """All-false masks remain all-false after upscale."""
+        masks = torch.zeros(2, 64, 64, dtype=torch.bool)
+        result = upscale_masks(masks, orig_size=(256, 256))
+
+        assert not result.any()
+
+    def test_upscale_empty_masks(self) -> None:
+        """Empty mask tensor is returned unchanged."""
+        masks = torch.empty(0, 64, 64, dtype=torch.bool)
+        result = upscale_masks(masks, orig_size=(256, 256))
+
+        assert result.numel() == 0
+
+    def test_upscale_single_mask(self) -> None:
+        """Single mask is correctly upscaled."""
+        masks = torch.zeros(1, 10, 10, dtype=torch.bool)
+        masks[0, 3:7, 3:7] = True  # center square
+        result = upscale_masks(masks, orig_size=(100, 100))
+
+        assert result.shape == (1, 100, 100)
+        assert result.dtype == torch.bool
+        # Center region should be true, corners should be false
+        assert result[0, 50, 50].item()
+        assert not result[0, 0, 0].item()
+
+
+class TestDownscaleResult:
+    """Tests for the DownscaleResult dataclass."""
+
+    def test_is_scaled_true_when_scale_below_one(self) -> None:
+        """is_scaled returns True when scale < 1.0."""
+        result = DownscaleResult(image=torch.empty(3, 100, 100), scale=0.5, orig_size=(200, 200))
+        assert result.is_scaled
+
+    def test_is_scaled_false_when_scale_is_one(self) -> None:
+        """is_scaled returns False when scale == 1.0."""
+        result = DownscaleResult(image=torch.empty(3, 200, 200), scale=1.0, orig_size=(200, 200))
+        assert not result.is_scaled
+
+
+class TestRoundTrip:
+    """Tests for downscale + upscale round-trip consistency."""
+
+    def test_round_trip_preserves_mask_coverage(self) -> None:
+        """Downscaling an image then upscaling masks preserves rough spatial coverage."""
+        h, w = 2776, 2082
+        image = torch.randn(3, h, w)
+
+        downscaled = downscale_image(image, max_side=1024)
+        work_h, work_w = downscaled.image.shape[1], downscaled.image.shape[2]
+
+        # Create masks at working resolution with a filled region
+        masks = torch.zeros(1, work_h, work_w, dtype=torch.bool)
+        masks[0, 10 : work_h - 10, 10 : work_w - 10] = True
+
+        restored = upscale_masks(masks, orig_size=(h, w))
+
+        assert restored.shape == (1, h, w)
+        # Center should be true, edges should be false
+        assert restored[0, h // 2, w // 2].item()
+        assert not restored[0, 0, 0].item()


### PR DESCRIPTION
## Description

**Problem**
SAM inference crashed with `UR_RESULT_ERROR_OUT_OF_RESOURCES` on large images (e.g. 2776×2082) - M&Ms dataset with many foreground points (143). GPU memory spiked from ~74MB to 18GB before the device ran out.

**Investigation**
Memory profiling revealed the following:

- [masks_to_boxes_traceable](https://github.com/open-edge-platform/geti-instant-learn/blob/4e9f814a6d9631eb2fbe67a4978308a11d0661d7/library/src/instantlearn/components/sam/decoder.py#L13) - materialised 4 coordinate grids of shape [N, H, W] in float32. For 142 masks at 2776×2082, that's ~13GB of intermediates.
- [all_masks](https://github.com/open-edge-platform/geti-instant-learn/blob/4e9f814a6d9631eb2fbe67a4978308a11d0661d7/library/src/instantlearn/components/sam/decoder.py#L290) buffer stored as float32 instead of bool, using 4× more memory than needed (925MB vs 231MB).
- SAM running on full resolution images - processing 143 prompts against a 2776×2082 image produced huge intermediate tensors, even though SAM internally works at 1024×1024 and its 256×256 logits are just upsampled to the output size with no quality benefit.

**Fix**
- `masks_to_boxes_traceable`: rewrote using axis projection (masks.any(dim=1/2)) to find bounding boxes on 1D vectors. Memory drops from O(N×H×W) to O(N×H + N×W) — a ~2400× reduction.
- `all_masks` dtype: changed to `torch.bool`.
- Image downscaling: `added max_image_side` parameter to SamDecoder. Images larger than this limit are proportionally downscaled before SAM, point prompts are scaled accordingly, and output masks are upscaled back to original resolution. Since SAM's effective resolution is 1024×1024, this preserves quality while dramatically cutting memory.
- Extracted `image_resize.py` utility: `downscale_image()` and `upscale_masks()` for reuse.


## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance