### PR TITLE
Read uv version from pyproject.toml

### DIFF
--- a/application/backend/Justfile
+++ b/application/backend/Justfile
@@ -10,8 +10,7 @@ stun-server := ""
 coturn-port := "443"
 dataset-dir := justfile_directory() + "/.data/templates/datasets"
 
-# Ensure version in GHA workflow matches uv version here
-uv_version := "0.10.0"
+uv_version := `grep -A 3 '\[tool\.uv\]' pyproject.toml | grep 'required-version' | sed 's/.*"[~=<>]*\([0-9][0-9.]*\)"/\1/'`
 device := "cpu" # cpu, cu128, xpu
 
 default:
@@ -36,7 +35,7 @@ dev: _venv (download-datasets dataset-dir)
 
 
 _pre-venv:
-    if ! uv self version | grep {{uv_version}} >/dev/null; then \
+    @if ! command -v uv > /dev/null; then \
         curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/astral-sh/uv/releases/download/{{uv_version}}/uv-installer.sh" | sh; \
     fi
 

--- a/library/Justfile
+++ b/library/Justfile
@@ -4,9 +4,7 @@ set shell := ["bash", "-cu"]
 
 py_path := "tests:src"
 
-# Ensure version in GHA workflow matches uv version here
-
-uv_version := "0.10.0"
+uv_version := `grep -A 3 '\[tool\.uv\]' pyproject.toml | grep 'required-version' | sed 's/.*"[~=<>]*\([0-9][0-9.]*\)"/\1/'`
 
 # Sphinx documentation variables
 
@@ -26,7 +24,7 @@ default:
 
 # Install uv
 pre-venv:
-    if ! uv self version | grep {{ uv_version }} >/dev/null; then \
+    @if ! command -v uv > /dev/null; then \
         curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/astral-sh/uv/releases/download/{{ uv_version }}/uv-installer.sh" | sh; \
     fi
 
@@ -97,7 +95,7 @@ download-lvis:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    LVIS_DIR="{{ lvis-directory }}" 
+    LVIS_DIR="{{ lvis-directory }}"
 
     if [ -d "$LVIS_DIR" ] && [ "$(ls -A "$LVIS_DIR")" ]; then
         echo "LVIS dataset directory already exists and is not empty. Skipping download."

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -119,6 +119,7 @@ version = { file = ["VERSION"] }
 [tool.uv]
 package = true
 managed = true
+required-version = "~=0.10.0"
 conflicts = [
     [
         { extra = "cpu" },


### PR DESCRIPTION
## Description

Use `pyproject.toml` as the single source of truth for uv version management.

## Changes

- Add `required-version = "~=0.10.0"` to the app and the library`[tool.uv]`
- Extract `uv_version` from pyproject.toml in both Justfiles instead of hardcoding it
- Replace strict version grep with presence-only check. (uv enforces version compatibility itself via `required-version`)

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance