### PR TITLE
Add feature similarity and grid_cells for Matcher to tackle small and large object detection 

### DIFF
--- a/application/backend/app/domain/services/schemas/processor.py
+++ b/application/backend/app/domain/services/schemas/processor.py
@@ -80,8 +80,12 @@ class MatcherConfig(BaseModelConfig):
     model_type: Literal[ModelType.MATCHER] = ModelType.MATCHER
     num_foreground_points: int = Field(default=5, gt=0, le=300)
     num_background_points: int = Field(default=3, ge=0, le=10)
-    confidence_threshold: float = Field(default=0.38, gt=0.0, lt=1.0)
+    # Optimal threshold varies by encoder: ~0.50 for dinov3_large, ~0.75 for dinov3_small.
+    # Using 0.75 as a safe universal default that minimizes cross-class false positives.
+    confidence_threshold: float = Field(default=0.75, gt=0.0, lt=1.0)
     use_mask_refinement: bool = Field(default=False)
+    similarity_threshold: float | None = Field(default=None, gt=0.0, lt=1.0)
+    num_grid_cells: int = Field(default=8, ge=0, le=100)
 
     model_config = {
         "json_schema_extra": {
@@ -89,11 +93,13 @@ class MatcherConfig(BaseModelConfig):
                 "model_type": "matcher",
                 "num_foreground_points": 5,
                 "num_background_points": 3,
-                "confidence_threshold": 0.38,
+                "confidence_threshold": 0.75,
                 "precision": "bf16",
                 "sam_model": "SAM-HQ-tiny",
                 "encoder_model": "dinov3_small",
                 "use_mask_refinement": False,
+                "similarity_threshold": None,
+                "num_grid_cells": 8,
             }
         }
     }

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -78,6 +78,8 @@ class ModelFactory:
                     num_background_points=config.num_background_points,
                     confidence_threshold=config.confidence_threshold,
                     use_mask_refinement=config.use_mask_refinement,
+                    similarity_threshold=config.similarity_threshold,
+                    num_grid_cells=config.num_grid_cells,
                     precision=precision,
                     device=selected_device,
                 )

--- a/application/backend/tests/unit/runtime/core/components/factories/test_model.py
+++ b/application/backend/tests/unit/runtime/core/components/factories/test_model.py
@@ -192,6 +192,8 @@ class TestModelFactory:
                 precision="fp32",
                 device="cpu",
                 use_mask_refinement=True,
+                similarity_threshold=None,
+                num_grid_cells=8,
                 sam=SAMModelName.SAM_HQ_TINY,
                 encoder_model="dinov3_small",
             )

--- a/application/ui/src/features/prompts/models/api/use-get-models.ts
+++ b/application/ui/src/features/prompts/models/api/use-get-models.ts
@@ -28,7 +28,7 @@ const getDefaultMatcherModel = (id: string): MatcherModel => {
     return {
         id,
         config: {
-            confidence_threshold: 0.38,
+            confidence_threshold: 0.75,
             model_type: 'matcher',
             num_background_points: 2,
             num_foreground_points: 40,
@@ -36,6 +36,8 @@ const getDefaultMatcherModel = (id: string): MatcherModel => {
             sam_model: 'SAM-HQ-tiny',
             encoder_model: 'dinov3_small',
             use_mask_refinement: false,
+            similarity_threshold: null,
+            num_grid_cells: 8,
         },
         active: false,
         name: `Matcher`,

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
@@ -92,6 +92,13 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
     const [decoderModel, setDecoderModel] = useState<DecoderModel>(model.config.sam_model);
     const [precision, setPrecision] = useState<Precision>(model.config.precision as Precision);
     const [useMaskRefinement, setUseMaskRefinement] = useState<boolean>(model.config.use_mask_refinement);
+    const [similarityThreshold, setSimilarityThreshold] = useState<number | null>(
+        model.config.similarity_threshold ?? null
+    );
+    const [useSimilarityThreshold, setUseSimilarityThreshold] = useState<boolean>(
+        model.config.similarity_threshold !== null && model.config.similarity_threshold !== undefined
+    );
+    const [numberOfGridCells, setNumberOfGridCells] = useState<number>(model.config.num_grid_cells);
 
     const updateModelMutation = useUpdateModel();
 
@@ -102,7 +109,9 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
         encoderModel === model.config.encoder_model &&
         decoderModel === model.config.sam_model &&
         precision === model.config.precision &&
-        useMaskRefinement === model.config.use_mask_refinement;
+        useMaskRefinement === model.config.use_mask_refinement &&
+        (useSimilarityThreshold ? similarityThreshold : null) === (model.config.similarity_threshold ?? null) &&
+        numberOfGridCells === model.config.num_grid_cells;
 
     const updateModel = (event: FormEvent) => {
         event.preventDefault();
@@ -120,6 +129,8 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
                     encoder_model: encoderModel,
                     sam_model: decoderModel,
                     use_mask_refinement: useMaskRefinement,
+                    similarity_threshold: useSimilarityThreshold ? similarityThreshold : null,
+                    num_grid_cells: numberOfGridCells,
                     precision,
                 },
             },
@@ -168,6 +179,38 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
                     onChange={setConfidenceThreshold}
                     value={confidenceThreshold}
                 />
+                <NumberField
+                    label={'Number of grid cells'}
+                    minValue={0}
+                    maxValue={100}
+                    step={1}
+                    onChange={setNumberOfGridCells}
+                    value={numberOfGridCells}
+                />
+                <Flex alignItems={'center'} width={'100%'} wrap={'wrap'}>
+                    <Switch
+                        isEmphasized
+                        isSelected={useSimilarityThreshold}
+                        onChange={(value) => {
+                            setUseSimilarityThreshold(value);
+                            if (value && similarityThreshold === null) {
+                                setSimilarityThreshold(0.65);
+                            }
+                        }}
+                    >
+                        Use similarity threshold
+                    </Switch>
+                </Flex>
+                {useSimilarityThreshold && (
+                    <NumberField
+                        label={'Similarity threshold'}
+                        minValue={0.01}
+                        maxValue={0.99}
+                        step={0.01}
+                        onChange={setSimilarityThreshold}
+                        value={similarityThreshold ?? 0.65}
+                    />
+                )}
                 <Selection label={'Precision'} value={precision} onChange={setPrecision} items={PRECISIONS} />
                 <Flex alignItems={'center'} width={'100%'} wrap={'wrap'}>
                     <Switch isEmphasized isSelected={useMaskRefinement} onChange={setUseMaskRefinement}>

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
@@ -106,7 +106,8 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
         decoderModel === model.config.sam_model &&
         precision === model.config.precision &&
         useMaskRefinement === model.config.use_mask_refinement &&
-        detectSmallObjects === (model.config.similarity_threshold !== null && model.config.similarity_threshold !== undefined);
+        detectSmallObjects ===
+            (model.config.similarity_threshold !== null && model.config.similarity_threshold !== undefined);
 
     const updateModel = (event: FormEvent) => {
         event.preventDefault();

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.component.tsx
@@ -92,13 +92,9 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
     const [decoderModel, setDecoderModel] = useState<DecoderModel>(model.config.sam_model);
     const [precision, setPrecision] = useState<Precision>(model.config.precision as Precision);
     const [useMaskRefinement, setUseMaskRefinement] = useState<boolean>(model.config.use_mask_refinement);
-    const [similarityThreshold, setSimilarityThreshold] = useState<number | null>(
-        model.config.similarity_threshold ?? null
-    );
-    const [useSimilarityThreshold, setUseSimilarityThreshold] = useState<boolean>(
+    const [detectSmallObjects, setDetectSmallObjects] = useState<boolean>(
         model.config.similarity_threshold !== null && model.config.similarity_threshold !== undefined
     );
-    const [numberOfGridCells, setNumberOfGridCells] = useState<number>(model.config.num_grid_cells);
 
     const updateModelMutation = useUpdateModel();
 
@@ -110,8 +106,7 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
         decoderModel === model.config.sam_model &&
         precision === model.config.precision &&
         useMaskRefinement === model.config.use_mask_refinement &&
-        (useSimilarityThreshold ? similarityThreshold : null) === (model.config.similarity_threshold ?? null) &&
-        numberOfGridCells === model.config.num_grid_cells;
+        detectSmallObjects === (model.config.similarity_threshold !== null && model.config.similarity_threshold !== undefined);
 
     const updateModel = (event: FormEvent) => {
         event.preventDefault();
@@ -129,8 +124,8 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
                     encoder_model: encoderModel,
                     sam_model: decoderModel,
                     use_mask_refinement: useMaskRefinement,
-                    similarity_threshold: useSimilarityThreshold ? similarityThreshold : null,
-                    num_grid_cells: numberOfGridCells,
+                    similarity_threshold: detectSmallObjects ? 0.65 : null,
+                    num_grid_cells: detectSmallObjects ? 8 : model.config.num_grid_cells,
                     precision,
                 },
             },
@@ -179,39 +174,12 @@ const MatcherConfiguration = ({ model, onClose }: MatcherConfigurationProps) => 
                     onChange={setConfidenceThreshold}
                     value={confidenceThreshold}
                 />
-                <NumberField
-                    label={'Number of grid cells'}
-                    minValue={0}
-                    maxValue={100}
-                    step={1}
-                    onChange={setNumberOfGridCells}
-                    value={numberOfGridCells}
-                />
+                <Selection label={'Precision'} value={precision} onChange={setPrecision} items={PRECISIONS} />
                 <Flex alignItems={'center'} width={'100%'} wrap={'wrap'}>
-                    <Switch
-                        isEmphasized
-                        isSelected={useSimilarityThreshold}
-                        onChange={(value) => {
-                            setUseSimilarityThreshold(value);
-                            if (value && similarityThreshold === null) {
-                                setSimilarityThreshold(0.65);
-                            }
-                        }}
-                    >
-                        Use similarity threshold
+                    <Switch isEmphasized isSelected={detectSmallObjects} onChange={setDetectSmallObjects}>
+                        Detect small objects
                     </Switch>
                 </Flex>
-                {useSimilarityThreshold && (
-                    <NumberField
-                        label={'Similarity threshold'}
-                        minValue={0.01}
-                        maxValue={0.99}
-                        step={0.01}
-                        onChange={setSimilarityThreshold}
-                        value={similarityThreshold ?? 0.65}
-                    />
-                )}
-                <Selection label={'Precision'} value={precision} onChange={setPrecision} items={PRECISIONS} />
                 <Flex alignItems={'center'} width={'100%'} wrap={'wrap'}>
                     <Switch isEmphasized isSelected={useMaskRefinement} onChange={setUseMaskRefinement}>
                         Use mask refinement

--- a/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
+++ b/application/ui/src/features/prompts/models/model-toolbar/model-configuration/model-configuration-dialog.test.tsx
@@ -99,6 +99,7 @@ describe('ModelConfigurationDialog', () => {
                 encoder_model: 'dinov3_small',
                 use_mask_refinement: true,
                 precision: 'bf16',
+                num_grid_cells: 8,
             },
         });
 

--- a/application/ui/src/setup-test.ts
+++ b/application/ui/src/setup-test.ts
@@ -87,6 +87,7 @@ const MOCKED_MODELS_RESPONSE: ModelListType = {
                 sam_model: 'SAM-HQ-tiny',
                 encoder_model: 'dinov3_large',
                 use_mask_refinement: false,
+                num_grid_cells: 8,
             },
             active: true,
             name: 'Mega model',

--- a/library/src/instantlearn/models/matcher/matcher.py
+++ b/library/src/instantlearn/models/matcher/matcher.py
@@ -193,7 +193,7 @@ class Matcher(Model):
         compile_models: bool = False,
         device: str = "cuda",
         postprocessor: PostProcessor | None = None,
-        similarity_threshold: float | None = 0.65,
+        similarity_threshold: float | None = None,
         num_grid_cells: int = 8,
     ) -> None:
         """Initialize the Matcher model.

--- a/library/src/instantlearn/models/matcher/matcher.py
+++ b/library/src/instantlearn/models/matcher/matcher.py
@@ -193,6 +193,8 @@ class Matcher(Model):
         compile_models: bool = False,
         device: str = "cuda",
         postprocessor: PostProcessor | None = None,
+        similarity_threshold: float | None = 0.65,
+        num_grid_cells: int = 8,
     ) -> None:
         """Initialize the Matcher model.
 
@@ -210,6 +212,13 @@ class Matcher(Model):
             postprocessor: Post-processor applied after predict().
                 Defaults to :func:`~instantlearn.components.postprocessing.default_postprocessor`
                 (MaskIoMNMS + BoxIoMNMS).
+            similarity_threshold: When set, supplement bidirectional-matched points with
+                additional target patches exceeding this similarity to the reference.
+                Helps detect more objects when reference masks cover few patches.
+                Set to None to disable. Default: None.
+            num_grid_cells: Grid cells per dimension for spatial diversity filtering.
+                When > 0, foreground points are deduplicated per grid cell before top-k
+                selection, preventing point clustering on large objects. Default: 0.
         """
         if postprocessor is None:
             postprocessor = default_postprocessor()
@@ -245,6 +254,8 @@ class Matcher(Model):
             encoder_feature_size=self.encoder.feature_size,
             num_foreground_points=num_foreground_points,
             num_background_points=num_background_points,
+            similarity_threshold=similarity_threshold,
+            num_grid_cells=num_grid_cells,
         )
 
         # SAM decoder

--- a/library/src/instantlearn/models/matcher/matcher.py
+++ b/library/src/instantlearn/models/matcher/matcher.py
@@ -218,7 +218,7 @@ class Matcher(Model):
                 Set to None to disable. Default: None.
             num_grid_cells: Grid cells per dimension for spatial diversity filtering.
                 When > 0, foreground points are deduplicated per grid cell before top-k
-                selection, preventing point clustering on large objects. Default: 0.
+                selection, preventing point clustering on large objects. Default: 8.
         """
         if postprocessor is None:
             postprocessor = default_postprocessor()

--- a/library/src/instantlearn/models/matcher/prompt_generators.py
+++ b/library/src/instantlearn/models/matcher/prompt_generators.py
@@ -3,14 +3,10 @@
 
 """Bidirectional prompt generator."""
 
-import logging
-
 import torch
 from torch import nn
 
 from instantlearn.components.linear_sum_assignment import linear_sum_assignment
-
-log = logging.getLogger(__name__)
 
 __all__ = ["BidirectionalPromptGenerator"]
 
@@ -162,17 +158,6 @@ class BidirectionalPromptGenerator(nn.Module):
         keep_indices = keep_mask.nonzero().squeeze(-1)
         valid_indices = [combined_ref[keep_indices], combined_target[keep_indices]]
         valid_scores = combined_scores[keep_indices]
-
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(
-                "[MATCHING] ref_indices=%d, forward_matches=%d, bidir_matches=%d, "
-                "fallback_used=%s, final_points=%d",
-                ref_idx.numel(),
-                fw_scores.numel(),
-                num_bidir,
-                ~has_valid,
-                valid_scores.numel(),
-            )
 
         return valid_indices, valid_scores
 
@@ -459,16 +444,8 @@ class BidirectionalPromptGenerator(nn.Module):
         foreground_points = self._convert_to_image_coords(foreground_points, original_size)
         foreground_labels = foreground_points.new_ones((foreground_points.size(0), 1))
         foreground_points = torch.cat([foreground_points, foreground_labels], dim=1)
-        fg_before_filter = foreground_points.size(0)
         # Filter to keep only top-scoring foreground points
         foreground_points = self._filter_foreground_points(foreground_points)
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(
-                "[PROMPTS] fg_before_filter=%d, fg_after_filter=%d, bg_points=%d",
-                fg_before_filter,
-                foreground_points.size(0),
-                background_indices.numel(),
-            )
 
         # Process background points
         background_points = self._extract_point_coordinates([None, background_indices], background_scores)

--- a/library/src/instantlearn/models/matcher/prompt_generators.py
+++ b/library/src/instantlearn/models/matcher/prompt_generators.py
@@ -163,15 +163,16 @@ class BidirectionalPromptGenerator(nn.Module):
         valid_indices = [combined_ref[keep_indices], combined_target[keep_indices]]
         valid_scores = combined_scores[keep_indices]
 
-        log.debug(
-            "[MATCHING] ref_indices=%d, forward_matches=%d, bidir_matches=%d, "
-            "fallback_used=%s, final_points=%d",
-            ref_idx.numel(),
-            fw_scores.numel(),
-            num_bidir,
-            not has_valid.item(),
-            valid_scores.numel(),
-        )
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(
+                "[MATCHING] ref_indices=%d, forward_matches=%d, bidir_matches=%d, "
+                "fallback_used=%s, final_points=%d",
+                ref_idx.numel(),
+                fw_scores.numel(),
+                num_bidir,
+                ~has_valid,
+                valid_scores.numel(),
+            )
 
         return valid_indices, valid_scores
 
@@ -207,9 +208,12 @@ class BidirectionalPromptGenerator(nn.Module):
         above_threshold = similarity_grid > self.similarity_threshold
         candidates = (above_threshold & is_local_max).flatten()
 
-        # Exclude already-matched indices
+        # Exclude already-matched indices without in-place advanced indexing
+        # (scatter-based approach is safe for ONNX export/tracing)
         if existing_target_indices is not None and existing_target_indices.numel() > 0:
-            candidates[existing_target_indices] = False
+            exclude_mask = torch.zeros_like(candidates)
+            exclude_mask.scatter_(0, existing_target_indices, torch.ones_like(existing_target_indices, dtype=torch.bool))
+            candidates = candidates & ~exclude_mask
 
         indices = candidates.nonzero().squeeze(-1)
         scores = similarity_grid.flatten()[indices]
@@ -221,10 +225,6 @@ class BidirectionalPromptGenerator(nn.Module):
             indices = indices[top_k_idx]
             scores = scores[top_k_idx]
 
-        return indices, scores
-
-        indices = candidates.nonzero().squeeze(-1)
-        scores = similarity_grid.flatten()[indices]
         return indices, scores
 
     def _select_background_points(
@@ -361,6 +361,11 @@ class BidirectionalPromptGenerator(nn.Module):
         y_cell = ((y_coords - y_min) / cell_h).floor().long().clamp(0, self.num_grid_cells - 1)
 
         cell_ids = y_cell * self.num_grid_cells + x_cell
+
+        # Skip grid filtering during ONNX export (data-dependent loops aren't traceable)
+        if torch.onnx.is_in_onnx_export():
+            return foreground_points
+
         unique_cells = torch.unique(cell_ids)
 
         selected = []
@@ -457,12 +462,13 @@ class BidirectionalPromptGenerator(nn.Module):
         fg_before_filter = foreground_points.size(0)
         # Filter to keep only top-scoring foreground points
         foreground_points = self._filter_foreground_points(foreground_points)
-        log.debug(
-            "[PROMPTS] fg_before_filter=%d, fg_after_filter=%d, bg_points=%d",
-            fg_before_filter,
-            foreground_points.size(0),
-            background_indices.numel(),
-        )
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(
+                "[PROMPTS] fg_before_filter=%d, fg_after_filter=%d, bg_points=%d",
+                fg_before_filter,
+                foreground_points.size(0),
+                background_indices.numel(),
+            )
 
         # Process background points
         background_points = self._extract_point_coordinates([None, background_indices], background_scores)

--- a/library/src/instantlearn/models/matcher/prompt_generators.py
+++ b/library/src/instantlearn/models/matcher/prompt_generators.py
@@ -34,7 +34,7 @@ class BidirectionalPromptGenerator(nn.Module):
             When > 0, foreground points are first deduplicated per grid cell (keeping the
             best-scoring point per cell), then the top-scoring points are selected.
             This prevents point clustering on large objects. Set to 0 to disable
-            (original top-k-only behavior). Default: 0.
+            (original top-k-only behavior). Default: 8.
     """
 
     def __init__(
@@ -45,7 +45,7 @@ class BidirectionalPromptGenerator(nn.Module):
         num_foreground_points: int = 40,
         num_background_points: int = 2,
         similarity_threshold: float | None = None,
-        num_grid_cells: int = 0,
+        num_grid_cells: int = 8,
     ) -> None:
         """Initialize the BidirectionalPromptGenerator."""
         super().__init__()

--- a/library/src/instantlearn/models/matcher/prompt_generators.py
+++ b/library/src/instantlearn/models/matcher/prompt_generators.py
@@ -3,10 +3,14 @@
 
 """Bidirectional prompt generator."""
 
+import logging
+
 import torch
 from torch import nn
 
 from instantlearn.components.linear_sum_assignment import linear_sum_assignment
+
+log = logging.getLogger(__name__)
 
 __all__ = ["BidirectionalPromptGenerator"]
 
@@ -26,6 +30,15 @@ class BidirectionalPromptGenerator(nn.Module):
         encoder_feature_size: Size of the feature map grid (e.g., 16, 64).
         num_foreground_points: Maximum number of foreground points to keep per class. Default: 40.
         num_background_points: Number of background points to generate per class. Default: 2.
+        similarity_threshold: When set, supplement bidirectional matched points with
+            additional target patches whose similarity to the masked reference exceeds
+            this value. This mitigates the ref-patch-count bottleneck for small objects.
+            Set to None to disable (original behavior). Default: None.
+        num_grid_cells: Number of grid cells per dimension for spatial diversity filtering.
+            When > 0, foreground points are first deduplicated per grid cell (keeping the
+            best-scoring point per cell), then the top-scoring points are selected.
+            This prevents point clustering on large objects. Set to 0 to disable
+            (original top-k-only behavior). Default: 0.
     """
 
     def __init__(
@@ -35,6 +48,8 @@ class BidirectionalPromptGenerator(nn.Module):
         encoder_feature_size: int,
         num_foreground_points: int = 40,
         num_background_points: int = 2,
+        similarity_threshold: float | None = None,
+        num_grid_cells: int = 0,
     ) -> None:
         """Initialize the BidirectionalPromptGenerator."""
         super().__init__()
@@ -44,6 +59,8 @@ class BidirectionalPromptGenerator(nn.Module):
         self.num_foreground_points = num_foreground_points
         self.num_background_points = num_background_points
         self.max_points = num_foreground_points + num_background_points
+        self.similarity_threshold = similarity_threshold
+        self.num_grid_cells = num_grid_cells
 
     @staticmethod
     def ref_to_target_matching(
@@ -146,7 +163,45 @@ class BidirectionalPromptGenerator(nn.Module):
         valid_indices = [combined_ref[keep_indices], combined_target[keep_indices]]
         valid_scores = combined_scores[keep_indices]
 
+        log.debug(
+            "[MATCHING] ref_indices=%d, forward_matches=%d, bidir_matches=%d, "
+            "fallback_used=%s, final_points=%d",
+            ref_idx.numel(),
+            fw_scores.numel(),
+            num_bidir,
+            not has_valid.item(),
+            valid_scores.numel(),
+        )
+
         return valid_indices, valid_scores
+
+    def _get_similarity_points(
+        self,
+        similarity_grid: torch.Tensor,
+        existing_target_indices: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Get additional foreground points from similarity map using threshold.
+
+        Selects all target patches whose similarity exceeds self.similarity_threshold,
+        excluding any already selected by bidirectional matching.
+
+        Args:
+            similarity_grid: Similarity map [feat_size, feat_size]
+            existing_target_indices: Already-selected target patch indices to deduplicate
+
+        Returns:
+            tuple of (target_indices [M], scores [M]) for new points
+        """
+        flat_sim = similarity_grid.flatten()  # [num_patches]
+        above_threshold = flat_sim > self.similarity_threshold
+
+        # Exclude already-matched indices
+        if existing_target_indices is not None and existing_target_indices.numel() > 0:
+            above_threshold[existing_target_indices] = False
+
+        indices = above_threshold.nonzero().squeeze(-1)
+        scores = flat_sim[indices]
+        return indices, scores
 
     def _select_background_points(
         self,
@@ -231,14 +286,20 @@ class BidirectionalPromptGenerator(nn.Module):
     def _filter_foreground_points(self, foreground_points: torch.Tensor) -> torch.Tensor:
         """Filter foreground points to keep only top-scoring ones.
 
+        When num_grid_cells > 0, applies grid-cell-based spatial diversity filtering
+        before the final top-k selection. This prevents point clustering on large objects
+        by keeping only the best-scoring point per grid cell, then selecting the top-k
+        from those spatially diverse points.
+
         Args:
             foreground_points: Foreground points [N, 4] with (x, y, score, label)
 
         Returns:
             Filtered foreground points [M, 4] where M <= num_foreground_points
         """
-        # Avoid conditional by using min(N, num_foreground_points) with topk
-        # topk handles both cases: if N <= k, it returns all N elements
+        if self.num_grid_cells > 0 and foreground_points.size(0) > self.num_foreground_points:
+            foreground_points = self._grid_cell_filter(foreground_points)
+
         n = foreground_points.size(0)
         k = (
             torch.minimum(n, torch.tensor(self.num_foreground_points))
@@ -247,6 +308,45 @@ class BidirectionalPromptGenerator(nn.Module):
         )
         _, top_indices = torch.topk(foreground_points[:, 2], k)
         return foreground_points[top_indices]
+
+    def _grid_cell_filter(self, foreground_points: torch.Tensor) -> torch.Tensor:
+        """Keep only the best-scoring point per spatial grid cell.
+
+        Divides the image into num_grid_cells x num_grid_cells cells and retains
+        the highest-scoring point in each occupied cell.
+
+        Args:
+            foreground_points: Points [N, 4] with (x, y, score, label) in image coords.
+
+        Returns:
+            Spatially diverse points [M, 4] where M <= num_occupied_cells.
+        """
+        x_coords = foreground_points[:, 0]
+        y_coords = foreground_points[:, 1]
+
+        # Compute cell size from coordinate range
+        x_min, x_max = x_coords.min(), x_coords.max()
+        y_min, y_max = y_coords.min(), y_coords.max()
+        x_range = (x_max - x_min).clamp(min=1.0)
+        y_range = (y_max - y_min).clamp(min=1.0)
+
+        cell_w = x_range / self.num_grid_cells
+        cell_h = y_range / self.num_grid_cells
+
+        x_cell = ((x_coords - x_min) / cell_w).floor().long().clamp(0, self.num_grid_cells - 1)
+        y_cell = ((y_coords - y_min) / cell_h).floor().long().clamp(0, self.num_grid_cells - 1)
+
+        cell_ids = y_cell * self.num_grid_cells + x_cell
+        unique_cells = torch.unique(cell_ids)
+
+        selected = []
+        for cell_id in unique_cells:
+            mask = cell_ids == cell_id
+            cell_points = foreground_points[mask]
+            best_idx = cell_points[:, 2].argmax()
+            selected.append(cell_points[best_idx : best_idx + 1])
+
+        return torch.cat(selected, dim=0)
 
     def _pad_points(self, points: torch.Tensor, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
         """Pad or truncate points tensor to exactly max_points size.
@@ -309,13 +409,36 @@ class BidirectionalPromptGenerator(nn.Module):
         # Perform foreground matching
         foreground_indices, foreground_scores = self._perform_matching(similarity_map, flatten_ref_mask)
 
+        # Supplement with similarity-threshold points if configured
+        if self.similarity_threshold is not None:
+            sim_indices, sim_scores = self._get_similarity_points(
+                local_similarity_grid, foreground_indices[1] if foreground_indices[1].numel() > 0 else None,
+            )
+            if sim_indices.numel() > 0:
+                # Merge: sim_indices are target patch indices; need same format as foreground_indices
+                combined_target = torch.cat([foreground_indices[1], sim_indices])
+                combined_ref = torch.cat([
+                    foreground_indices[0],
+                    torch.zeros_like(sim_indices),  # dummy ref indices for threshold points
+                ])
+                combined_scores = torch.cat([foreground_scores, sim_scores])
+                foreground_indices = [combined_ref, combined_target]
+                foreground_scores = combined_scores
+
         # Process foreground points
         foreground_points = self._extract_point_coordinates(foreground_indices, foreground_scores)
         foreground_points = self._convert_to_image_coords(foreground_points, original_size)
         foreground_labels = foreground_points.new_ones((foreground_points.size(0), 1))
         foreground_points = torch.cat([foreground_points, foreground_labels], dim=1)
+        fg_before_filter = foreground_points.size(0)
         # Filter to keep only top-scoring foreground points
         foreground_points = self._filter_foreground_points(foreground_points)
+        log.debug(
+            "[PROMPTS] fg_before_filter=%d, fg_after_filter=%d, bg_points=%d",
+            fg_before_filter,
+            foreground_points.size(0),
+            background_indices.numel(),
+        )
 
         # Process background points
         background_points = self._extract_point_coordinates([None, background_indices], background_scores)

--- a/library/src/instantlearn/models/matcher/prompt_generators.py
+++ b/library/src/instantlearn/models/matcher/prompt_generators.py
@@ -180,10 +180,16 @@ class BidirectionalPromptGenerator(nn.Module):
         similarity_grid: torch.Tensor,
         existing_target_indices: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Get additional foreground points from similarity map using threshold.
+        """Get additional foreground points from similarity map using threshold with local peak NMS.
 
-        Selects all target patches whose similarity exceeds self.similarity_threshold,
-        excluding any already selected by bidirectional matching.
+        Instead of returning ALL patches above threshold (which creates many redundant
+        points that produce overlapping SAM masks), returns only local maxima — patches
+        that are the highest-scoring in their 3x3 neighborhood AND above threshold.
+        This naturally deduplicates adjacent patches (e.g., multiple patches covering
+        the same small object) while preserving one representative point per region.
+
+        The result is further capped at num_foreground_points to limit the number of
+        supplementary points and avoid excessive SAM decode calls.
 
         Args:
             similarity_grid: Similarity map [feat_size, feat_size]
@@ -192,15 +198,33 @@ class BidirectionalPromptGenerator(nn.Module):
         Returns:
             tuple of (target_indices [M], scores [M]) for new points
         """
-        flat_sim = similarity_grid.flatten()  # [num_patches]
-        above_threshold = flat_sim > self.similarity_threshold
+        # Local peak NMS: keep only patches that are the max in their 3x3 neighborhood
+        sim_4d = similarity_grid.unsqueeze(0).unsqueeze(0)  # [1, 1, H, W]
+        local_max = torch.nn.functional.max_pool2d(sim_4d, kernel_size=3, stride=1, padding=1)
+        is_local_max = similarity_grid == local_max.squeeze(0).squeeze(0)
+
+        # Combine: must be above threshold AND a local peak
+        above_threshold = similarity_grid > self.similarity_threshold
+        candidates = (above_threshold & is_local_max).flatten()
 
         # Exclude already-matched indices
         if existing_target_indices is not None and existing_target_indices.numel() > 0:
-            above_threshold[existing_target_indices] = False
+            candidates[existing_target_indices] = False
 
-        indices = above_threshold.nonzero().squeeze(-1)
-        scores = flat_sim[indices]
+        indices = candidates.nonzero().squeeze(-1)
+        scores = similarity_grid.flatten()[indices]
+
+        # Cap supplementary points to avoid excessive SAM decode calls.
+        # Uses num_foreground_points as the maximum budget for threshold-based points.
+        if indices.numel() > self.num_foreground_points:
+            _, top_k_idx = torch.topk(scores, self.num_foreground_points)
+            indices = indices[top_k_idx]
+            scores = scores[top_k_idx]
+
+        return indices, scores
+
+        indices = candidates.nonzero().squeeze(-1)
+        scores = similarity_grid.flatten()[indices]
         return indices, scores
 
     def _select_background_points(

--- a/library/src/instantlearn/utils/args.py
+++ b/library/src/instantlearn/utils/args.py
@@ -74,8 +74,14 @@ def populate_benchmark_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--num_grid_cells",
         type=int,
-        default=16,
+        default=8,
         help="Number of grid cells to use for the grid prompt generator",
+    )
+    parser.add_argument(
+        "--similarity_threshold",
+        type=float,
+        default=None,
+        help="Similarity threshold for supplementary foreground points. Set to None to disable.",
     )
     parser.add_argument(
         "--overwrite",

--- a/library/src/instantlearn/utils/benchmark.py
+++ b/library/src/instantlearn/utils/benchmark.py
@@ -210,6 +210,8 @@ def load_model(sam: SAMModelName, model_name: ModelName, args: Namespace) -> Mod
                 num_foreground_points=args.num_foreground_points,
                 num_background_points=args.num_background_points,
                 confidence_threshold=args.confidence_threshold,
+                similarity_threshold=args.similarity_threshold,
+                num_grid_cells=args.num_grid_cells,
                 precision=args.precision,
                 compile_models=args.compile_models,
                 device=args.device,


### PR DESCRIPTION
# Pull Request
This PR solves two issues with Matcher.
### Problem 1: Small objects produce too few foreground points
Root cause: The reference mask is pooled onto the encoder's patch grid (e.g., 32×32 = 1024 patches for dinov3_large at 512px input). A small object (like a single candy) may only cover 8 out of 1024 patches. Bidirectional matching can only produce matches for patches that are under the mask — so we get at most 8 foreground points, regardless of num_foreground_points. With only 8 points, SAM doesn't get enough spatial coverage to segment all instances of that object across the target image


To solve this - Added `_get_similarity_points()` in prompt_generators.py. After bidirectional matching, it scans the similarity map and selects all target patches whose cosine similarity to the masked reference exceeds the threshold. These points supplement the bidirectional matches.

This ensures that even when the mask covers few patches, the model finds additional matching regions in the target through direct similarity comparison — the same mechanism PerDino 


The threshold of 0.65 is chosen after running sweep experiements on example and other datasets. 



### Problem 2: Large objects cause point clustering → NMS collapse
Root cause: For large objects (like potatoes filling much of the image), bidirectional matching produces many high-scoring points — but they all cluster on the same 1–2 object instances. The top-k selection (e.g., top-40 by score) picks the 40 highest-scoring points, which are all on the same potato. SAM then generates overlapping masks for the same object, and NMS collapses them into 1–2 detections instead of finding all 8 potatoes.
Soltuion : Added _grid_cell_filter() in prompt_generators.py. Before top-k selection, it divides the point coordinate space into an N×N grid (default 8×8 = 64 cells) and keeps only the best-scoring point per occupied cell. This enforces spatial diversity. After filtering, the top-k points are spread across different spatial regions, ensuring SAM receives prompts pointing to different object instances.
Grid filtering only removes redundant points on the same object. It never reduces detection of new objects. Setting num_grid_cells=0 disables it.


RESULTS/BENCHMARK : https://github.com/open-edge-platform/geti-instant-learn/pull/929#issuecomment-4245393271 

## Type of Change

- [ ] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
