### PR TITLE
Add Label Captions to Bounding Boxes 

### DIFF
--- a/application/backend/app/domain/services/schemas/label.py
+++ b/application/backend/app/domain/services/schemas/label.py
@@ -43,6 +43,14 @@ class RGBColor:
 
 
 @dataclass(frozen=True)
+class LabelInfo:
+    """Resolved label metadata for a single category during visualization."""
+
+    color: tuple[int, int, int]
+    name: str | None = None
+
+
+@dataclass(frozen=True)
 class VisualizationLabel:
     """Label data needed for visualization."""
 

--- a/application/backend/app/domain/services/schemas/label.py
+++ b/application/backend/app/domain/services/schemas/label.py
@@ -43,14 +43,6 @@ class RGBColor:
 
 
 @dataclass(frozen=True)
-class LabelInfo:
-    """Resolved label metadata for a single category during visualization."""
-
-    color: tuple[int, int, int]
-    name: str | None = None
-
-
-@dataclass(frozen=True)
 class VisualizationLabel:
     """Label data needed for visualization."""
 

--- a/application/backend/app/runtime/webrtc/visualizer.py
+++ b/application/backend/app/runtime/webrtc/visualizer.py
@@ -1,12 +1,15 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
+from typing import Protocol
 
 import cv2
 import numpy as np
 
-from domain.services.schemas.label import VisualizationInfo
+from domain.services.schemas.label import LabelInfo, VisualizationInfo
 from domain.services.schemas.processor import OutputData
 from settings import get_settings
 
@@ -15,20 +18,186 @@ logger = logging.getLogger(__name__)
 DEFAULT_FALLBACK_COLOR: tuple[int, int, int] = (128, 128, 128)
 
 
-class InferenceVisualizer:
+class CategoryResolver:
+    """Resolve category IDs to label metadata (color, name).
+
+    Encapsulates the category_id → label_id → LabelInfo lookup chain.
+    Falls back to deterministic colors for unmapped categories and a neutral
+    fallback when no category is available.
     """
-    Overlay model predictions onto RGB frames for WebRTC streaming.
 
-    The visualizer expects `OutputData.results` items to follow the model's prediction dict
-    convention (e.g. `pred_masks`, `pred_labels`, optional `pred_boxes`).
+    def __init__(self, visualization_info: VisualizationInfo | None = None) -> None:
+        self._category_id_to_label_id: dict[int, str] = {}
+        self._label_id_to_info: dict[str, LabelInfo] = {}
 
-    Color resolution uses:
-      1) `category_id` from `pred_labels` (tensor/int) -> Python `int`
-      2) `category_id_to_label_id[category_id]` -> label UUID `str`
-      3) `label_colors[label_uuid]` -> RGB tuple
+        if visualization_info is not None:
+            self._category_id_to_label_id = visualization_info.category_mappings.category_id_to_label_id
+            self._label_id_to_info = {
+                str(item.id): LabelInfo(color=item.color.to_tuple(), name=item.object_name)
+                for item in visualization_info.label_colors
+            }
 
-    If a category cannot be resolved to a configured label color, a deterministic per-category
-    color is generated. If the category itself is missing, a neutral fallback is used.
+    def resolve(self, category_id: int | None) -> LabelInfo:
+        """Return label metadata for a predicted category."""
+        if category_id is None:
+            return LabelInfo(color=DEFAULT_FALLBACK_COLOR)
+
+        label_id = self._category_id_to_label_id.get(category_id)
+        if label_id is None:
+            logger.warning("No label mapping found for category_id=%d", category_id)
+            return LabelInfo(color=generate_deterministic_color(category_id))
+
+        info = self._label_id_to_info.get(label_id)
+        if info is None:
+            logger.warning("No color found for label_id=%s (category_id=%d)", label_id, category_id)
+            return LabelInfo(color=generate_deterministic_color(category_id))
+
+        logger.debug("Category %d -> label %s -> color %s", category_id, label_id, info.color)
+        return info
+
+    @staticmethod
+    def extract_category_id(labels: np.ndarray | None, index: int) -> int | None:
+        """Extract category ID from a numpy label array at the given index."""
+        if labels is None or index >= len(labels):
+            return None
+        return int(labels[index])
+
+
+class OverlayRenderer(Protocol):
+    """Strategy interface for rendering a specific overlay type onto a frame."""
+
+    def draw(
+        self,
+        frame: np.ndarray,
+        prediction: dict[str, np.ndarray],
+        labels: np.ndarray | None,
+    ) -> np.ndarray: ...
+
+
+class MaskRenderer:
+    """Render colored mask overlays and contours onto a frame."""
+
+    def __init__(self, mask_alpha: float, outline_thickness: int, resolver: CategoryResolver) -> None:
+        self._alpha = mask_alpha
+        self._outline_thickness = outline_thickness
+        self._resolver = resolver
+
+    def draw(
+        self,
+        frame: np.ndarray,
+        prediction: dict[str, np.ndarray],
+        labels: np.ndarray | None,
+    ) -> np.ndarray:
+        masks = prediction.get("pred_masks")
+        if masks is None or masks.size == 0:
+            return frame
+
+        labels_np = labels if labels is not None and labels.size > 0 else None
+        overlay = frame.copy()
+
+        for mask_idx, mask in enumerate(masks):
+            category_id = self._resolver.extract_category_id(labels_np, mask_idx)
+            info = self._resolver.resolve(category_id)
+
+            mask_bool = mask > 0.5
+            overlay = self._apply_overlay(overlay, mask_bool, info.color)
+            overlay = self._draw_contours(overlay, mask_bool, info.color)
+
+        return overlay
+
+    def _apply_overlay(self, frame: np.ndarray, mask_bool: np.ndarray, color: tuple[int, int, int]) -> np.ndarray:
+        frame[mask_bool] = (
+            frame[mask_bool] * (1 - self._alpha) + np.array(color, dtype=np.float32) * self._alpha
+        ).astype(np.uint8)
+        return frame
+
+    def _draw_contours(self, frame: np.ndarray, mask_bool: np.ndarray, color: tuple[int, int, int]) -> np.ndarray:
+        mask_uint8 = (mask_bool * 255).astype(np.uint8)
+        contours, _ = cv2.findContours(mask_uint8, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        cv2.drawContours(frame, contours, -1, color, self._outline_thickness)
+        return frame
+
+
+class BoxRenderer:
+    """Render bounding boxes with optional label captions onto a frame."""
+
+    def __init__(
+        self,
+        box_thickness: int,
+        visualize_labels: bool,
+        label_font_scale: float,
+        resolver: CategoryResolver,
+    ) -> None:
+        self._box_thickness = box_thickness
+        self._visualize_labels = visualize_labels
+        self._label_font_scale = label_font_scale
+        self._resolver = resolver
+
+    def draw(
+        self,
+        frame: np.ndarray,
+        prediction: dict[str, np.ndarray],
+        labels: np.ndarray | None,
+    ) -> np.ndarray:
+        boxes = prediction.get("pred_boxes")
+        if boxes is None or boxes.size == 0:
+            return frame
+
+        labels_np = labels if labels is not None and labels.size > 0 else None
+
+        for box_idx, box in enumerate(boxes):
+            category_id = self._resolver.extract_category_id(labels_np, box_idx)
+            info = self._resolver.resolve(category_id)
+
+            x1, y1, x2, y2 = int(box[0]), int(box[1]), int(box[2]), int(box[3])
+            cv2.rectangle(frame, (x1, y1), (x2, y2), info.color, self._box_thickness)
+
+            if self._visualize_labels:
+                score = float(box[4]) if len(box) > 4 else None
+                self._draw_caption(frame, x1, y1, info.name, score, info.color)
+
+        return frame
+
+    def _draw_caption(
+        self,
+        frame: np.ndarray,
+        x1: int,
+        y1: int,
+        label_name: str | None,
+        score: float | None,
+        color: tuple[int, int, int],
+    ) -> None:
+        parts: list[str] = []
+        if label_name:
+            parts.append(label_name)
+        if score is not None:
+            parts.append(f"{100 * score:.0f}%")
+        if not parts:
+            return
+
+        caption = " ".join(parts)
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        thickness = 1
+        (text_w, text_h), baseline = cv2.getTextSize(caption, font, self._label_font_scale, thickness)
+
+        text_y = max(y1 - 6, text_h + 2)
+        text_x = x1
+
+        cv2.rectangle(
+            frame,
+            (text_x, text_y - text_h - 2),
+            (text_x + text_w + 2, text_y + baseline),
+            color,
+            cv2.FILLED,
+        )
+        cv2.putText(frame, caption, (text_x + 1, text_y), font, self._label_font_scale, (255, 255, 255), thickness)
+
+
+class InferenceVisualizer:
+    """Overlay model predictions onto RGB frames for WebRTC streaming.
+
+    Composes a list of ``OverlayRenderer`` strategies (masks, boxes) based on
+    application settings.  The public API — ``visualize()`` — remains unchanged.
     """
 
     def __init__(self, enable_visualization: bool = True) -> None:
@@ -39,184 +208,50 @@ class InferenceVisualizer:
         self._mask_alpha = settings.mask_alpha
         self._mask_outline_thickness = settings.mask_outline_thickness
         self._box_thickness = settings.box_thickness
+        self._visualize_labels = settings.visualize_labels
+        self._label_font_scale = settings.label_font_scale
+
+    def _build_renderers(self, resolver: CategoryResolver) -> list[OverlayRenderer]:
+        """Create renderer instances for the current visualization pass."""
+        renderers: list[OverlayRenderer] = []
+        if self._visualize_masks:
+            renderers.append(
+                MaskRenderer(
+                    mask_alpha=self._mask_alpha, outline_thickness=self._mask_outline_thickness, resolver=resolver
+                )
+            )
+        if self._visualize_boxes:
+            renderers.append(
+                BoxRenderer(
+                    box_thickness=self._box_thickness,
+                    visualize_labels=self._visualize_labels,
+                    label_font_scale=self._label_font_scale,
+                    resolver=resolver,
+                )
+            )
+        return renderers
 
     def visualize(self, output_data: OutputData, visualization_info: VisualizationInfo | None = None) -> np.ndarray:
         """Render model predictions onto the frame."""
-
         if not self._enabled or not output_data.results:
             return output_data.frame
 
         annotated = output_data.frame.copy()
-        category_id_to_label_id: dict[int, str] = {}
-        label_id_to_color: dict[str, tuple[int, int, int]] = {}
+        resolver = CategoryResolver(visualization_info)
+        renderers = self._build_renderers(resolver)
 
-        if visualization_info is not None:
-            category_id_to_label_id = visualization_info.category_mappings.category_id_to_label_id
-            label_id_to_color = {str(item.id): item.color.to_tuple() for item in visualization_info.label_colors}
-
-        logger.debug("Visualizing the output data: %s, categories=%s", output_data, category_id_to_label_id)
+        logger.debug("Visualizing %d predictions", len(output_data.results))
         for prediction in output_data.results:
             labels = prediction.get("pred_labels")
-
-            if self._visualize_masks:
-                masks = prediction.get("pred_masks")
-                if masks is not None and masks.size > 0:
-                    annotated = self._draw_masks(annotated, masks, labels, label_id_to_color, category_id_to_label_id)
-
-            if self._visualize_boxes:
-                boxes = prediction.get("pred_boxes")
-                if boxes is not None and boxes.size > 0:
-                    annotated = self._draw_boxes(annotated, boxes, labels, label_id_to_color, category_id_to_label_id)
+            for renderer in renderers:
+                annotated = renderer.draw(annotated, prediction, labels)
 
         return annotated
 
-    def _draw_masks(
-        self,
-        frame: np.ndarray,
-        masks: np.ndarray,
-        labels: np.ndarray | None,
-        label_colors: dict[str, tuple[int, int, int]],
-        category_id_to_label_id: dict[int, str],
-    ) -> np.ndarray:
-        """
-        Draw colored mask overlays and contours for a prediction.
 
-        Args:
-            frame: RGB frame to draw on.
-            masks: Array of shape [N, H, W] with mask logits/probabilities.
-            labels: Array of shape [N] with category IDs for each mask.
-            label_colors: Mapping of label UUID (str) to RGB color tuple.
-            category_id_to_label_id: Mapping of category ID (int) to label UUID (str).
-
-        Returns:
-            A new RGB frame with mask overlays applied.
-        """
-        labels_np: np.ndarray | None = None
-        if labels is not None and labels.size > 0:
-            labels_np = labels
-        overlay = frame.copy()
-
-        for mask_idx, mask in enumerate(masks):
-            category_id = self._extract_category_id_from_array(labels_np, mask_idx)
-            color = self._resolve_color_for_category(category_id, label_colors, category_id_to_label_id)
-
-            mask_bool = mask > 0.5
-            overlay = self._apply_mask_overlay(overlay, mask_bool, color)
-            overlay = self._draw_mask_contours(overlay, mask_bool, color)
-
-        return overlay
-
-    def _draw_boxes(
-        self,
-        frame: np.ndarray,
-        boxes: np.ndarray,
-        labels: np.ndarray | None,
-        label_colors: dict[str, tuple[int, int, int]],
-        category_id_to_label_id: dict[int, str],
-    ) -> np.ndarray:
-        """
-        Draw bounding boxes for a prediction.
-
-        Args:
-            frame: RGB frame to draw on.
-            boxes: Array of shape [N, 4] or [N, 5] with box coords [x1, y1, x2, y2, (score)].
-            labels: Array of shape [N] with category IDs for each box.
-            label_colors: Mapping of label UUID (str) to RGB color tuple.
-            category_id_to_label_id: Mapping of category ID (int) to label UUID (str).
-
-        Returns:
-            A new RGB frame with bounding boxes drawn.
-        """
-        labels_np: np.ndarray | None = None
-        if labels is not None and labels.size > 0:
-            labels_np = labels
-
-        for box_idx, box in enumerate(boxes):
-            category_id = self._extract_category_id_from_array(labels_np, box_idx)
-            color = self._resolve_color_for_category(category_id, label_colors, category_id_to_label_id)
-
-            x1, y1, x2, y2 = int(box[0]), int(box[1]), int(box[2]), int(box[3])
-            cv2.rectangle(frame, (x1, y1), (x2, y2), color, self._box_thickness)
-
-        return frame
-
-    @staticmethod
-    def _extract_category_id_from_array(labels_np: np.ndarray | None, index: int) -> int | None:
-        """
-        Extract category ID from numpy array.
-
-        Args:
-            labels_np: Numpy array of predicted category IDs (already on CPU).
-            index: Index of the mask/label to read.
-
-        Returns:
-            Category ID as int, or None if unavailable.
-        """
-        if labels_np is None or index >= len(labels_np):
-            return None
-        return int(labels_np[index])
-
-    def _resolve_color_for_category(
-        self,
-        category_id: int | None,
-        label_colors: dict[str, tuple[int, int, int]],
-        category_id_to_label_id: dict[int, str],
-    ) -> tuple[int, int, int]:
-        """
-        Resolve an RGB color for a predicted category.
-
-        Args:
-            category_id: Predicted category ID.
-            label_colors: Mapping from label UUID to RGB.
-            category_id_to_label_id: Mapping from category ID to label UUID.
-        """
-        if category_id is None:
-            return DEFAULT_FALLBACK_COLOR
-
-        label_id = category_id_to_label_id.get(category_id)
-
-        if label_id is None:
-            logger.warning("No label mapping found for category_id=%d", category_id)
-            return self._generate_deterministic_color(category_id)
-
-        color = label_colors.get(label_id)
-
-        if color is None:
-            logger.warning("No color found for label_id=%s (category_id=%d)", label_id, category_id)
-            return self._generate_deterministic_color(category_id)
-
-        logger.debug("Category %d -> label %s -> color %s", category_id, label_id, color)
-        return color
-
-    def _apply_mask_overlay(self, frame: np.ndarray, mask_bool: np.ndarray, color: tuple[int, int, int]) -> np.ndarray:
-        """
-        Alpha-blend a single mask into the frame.
-
-        Args:
-            frame: RGB frame to blend into.
-            mask_bool: Boolean mask (H, W) selecting pixels to blend.
-            color: RGB overlay color.
-        """
-        frame[mask_bool] = (
-            frame[mask_bool] * (1 - self._mask_alpha) + np.array(color, dtype=np.float32) * self._mask_alpha
-        ).astype(np.uint8)
-        return frame
-
-    def _draw_mask_contours(self, frame: np.ndarray, mask_bool: np.ndarray, color: tuple[int, int, int]) -> np.ndarray:
-        """
-        Draw mask contours on the frame.
-        """
-        mask_uint8 = (mask_bool * 255).astype(np.uint8)
-        contours, _ = cv2.findContours(mask_uint8, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        cv2.drawContours(frame, contours, -1, color, self._mask_outline_thickness)
-        return frame
-
-    @staticmethod
-    def _generate_deterministic_color(index: int) -> tuple[int, int, int]:
-        """
-        Generate a stable RGB color for a numeric category ID.
-        """
-        hue = (index * 67) % 180
-        hsv_color = np.array([[[hue, 255, 255]]], dtype=np.uint8)
-        rgb_color = cv2.cvtColor(hsv_color, cv2.COLOR_HSV2RGB)[0, 0]
-        return int(rgb_color[0]), int(rgb_color[1]), int(rgb_color[2])
+def generate_deterministic_color(index: int) -> tuple[int, int, int]:
+    """Generate a stable RGB color for a numeric category ID."""
+    hue = (index * 67) % 180
+    hsv_color = np.array([[[hue, 255, 255]]], dtype=np.uint8)
+    rgb_color = cv2.cvtColor(hsv_color, cv2.COLOR_HSV2RGB)[0, 0]
+    return int(rgb_color[0]), int(rgb_color[1]), int(rgb_color[2])

--- a/application/backend/app/runtime/webrtc/visualizer.py
+++ b/application/backend/app/runtime/webrtc/visualizer.py
@@ -5,52 +5,51 @@ from __future__ import annotations
 
 import logging
 from typing import Protocol
+from uuid import UUID
 
 import cv2
 import numpy as np
 
-from domain.services.schemas.label import LabelInfo, VisualizationInfo
+from domain.services.schemas.label import RGBColor, VisualizationInfo, VisualizationLabel
 from domain.services.schemas.processor import OutputData
 from settings import get_settings
 
 logger = logging.getLogger(__name__)
 
+_FALLBACK_ID = UUID(int=0)
 DEFAULT_FALLBACK_COLOR: tuple[int, int, int] = (128, 128, 128)
 
 
 class CategoryResolver:
-    """Resolve category IDs to label metadata (color, name).
+    """Resolve category IDs to visualization labels.
 
-    Encapsulates the category_id → label_id → LabelInfo lookup chain.
+    Encapsulates the category_id → label_id → VisualizationLabel lookup chain.
     Falls back to deterministic colors for unmapped categories and a neutral
     fallback when no category is available.
     """
 
     def __init__(self, visualization_info: VisualizationInfo | None = None) -> None:
         self._category_id_to_label_id: dict[int, str] = {}
-        self._label_id_to_info: dict[str, LabelInfo] = {}
+        self._label_id_to_vis: dict[str, VisualizationLabel] = {}
 
         if visualization_info is not None:
             self._category_id_to_label_id = visualization_info.category_mappings.category_id_to_label_id
-            self._label_id_to_info = {
-                str(item.id): LabelInfo(color=item.color.to_tuple(), name=item.object_name)
-                for item in visualization_info.label_colors
-            }
+            self._label_id_to_vis = {str(item.id): item for item in visualization_info.label_colors}
 
-    def resolve(self, category_id: int | None) -> LabelInfo:
-        """Return label metadata for a predicted category."""
+    def resolve(self, category_id: int | None) -> VisualizationLabel:
+        """Return visualization label for a predicted category."""
         if category_id is None:
-            return LabelInfo(color=DEFAULT_FALLBACK_COLOR)
+            return VisualizationLabel(id=_FALLBACK_ID, color=RGBColor(*DEFAULT_FALLBACK_COLOR))
 
         label_id = self._category_id_to_label_id.get(category_id)
         if label_id is None:
             logger.warning("No label mapping found for category_id=%d", category_id)
-            return LabelInfo(color=generate_deterministic_color(category_id))
+            return VisualizationLabel(id=_FALLBACK_ID, color=RGBColor(*generate_deterministic_color(category_id)))
 
-        info = self._label_id_to_info.get(label_id)
+        info = self._label_id_to_vis.get(label_id)
         if info is None:
             logger.warning("No color found for label_id=%s (category_id=%d)", label_id, category_id)
-            return LabelInfo(color=generate_deterministic_color(category_id))
+            return VisualizationLabel(id=_FALLBACK_ID, color=RGBColor(*generate_deterministic_color(category_id)))
 
         logger.debug("Category %d -> label %s -> color %s", category_id, label_id, info.color)
         return info
@@ -98,10 +97,11 @@ class MaskRenderer:
         for mask_idx, mask in enumerate(masks):
             category_id = self._resolver.extract_category_id(labels_np, mask_idx)
             info = self._resolver.resolve(category_id)
+            color = info.color.to_tuple()
 
             mask_bool = mask > 0.5
-            overlay = self._apply_overlay(overlay, mask_bool, info.color)
-            overlay = self._draw_contours(overlay, mask_bool, info.color)
+            overlay = self._apply_overlay(overlay, mask_bool, color)
+            overlay = self._draw_contours(overlay, mask_bool, color)
 
         return overlay
 
@@ -148,13 +148,14 @@ class BoxRenderer:
         for box_idx, box in enumerate(boxes):
             category_id = self._resolver.extract_category_id(labels_np, box_idx)
             info = self._resolver.resolve(category_id)
+            color = info.color.to_tuple()
 
             x1, y1, x2, y2 = int(box[0]), int(box[1]), int(box[2]), int(box[3])
-            cv2.rectangle(frame, (x1, y1), (x2, y2), info.color, self._box_thickness)
+            cv2.rectangle(frame, (x1, y1), (x2, y2), color, self._box_thickness)
 
             if self._visualize_labels:
                 score = float(box[4]) if len(box) > 4 else None
-                self._draw_caption(frame, x1, y1, info.name, score, info.color)
+                self._draw_caption(frame, x1, y1, info.object_name, score, color)
 
         return frame
 
@@ -177,7 +178,7 @@ class BoxRenderer:
 
         caption = " ".join(parts)
         font = cv2.FONT_HERSHEY_SIMPLEX
-        thickness = 1
+        thickness = 2
         (text_w, text_h), baseline = cv2.getTextSize(caption, font, self._label_font_scale, thickness)
 
         text_y = max(y1 - 6, text_h + 2)

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -139,9 +139,11 @@ class Settings(BaseSettings):
     # Inference visualization settings
     visualize_masks: bool = Field(default=False, alias="VISUALIZE_MASKS")
     visualize_boxes: bool = Field(default=True, alias="VISUALIZE_BOXES")
+    visualize_labels: bool = Field(default=True, alias="VISUALIZE_LABELS")
     mask_alpha: float = Field(default=0.5, alias="MASK_ALPHA")
     mask_outline_thickness: int = Field(default=3, alias="MASK_OUTLINE_THICKNESS")
     box_thickness: int = Field(default=4, alias="BOX_THICKNESS")
+    label_font_scale: float = Field(default=0.5, alias="LABEL_FONT_SCALE")
 
     @property
     def ice_servers(self) -> list[dict]:

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -143,7 +143,7 @@ class Settings(BaseSettings):
     mask_alpha: float = Field(default=0.5, alias="MASK_ALPHA")
     mask_outline_thickness: int = Field(default=3, alias="MASK_OUTLINE_THICKNESS")
     box_thickness: int = Field(default=4, alias="BOX_THICKNESS")
-    label_font_scale: float = Field(default=0.5, alias="LABEL_FONT_SCALE")
+    label_font_scale: float = Field(default=2.0, alias="LABEL_FONT_SCALE")
 
     @property
     def ice_servers(self) -> list[dict]:

--- a/application/backend/tests/unit/runtime/webrtc/test_visualizer.py
+++ b/application/backend/tests/unit/runtime/webrtc/test_visualizer.py
@@ -7,9 +7,20 @@ from uuid import UUID
 import numpy as np
 import pytest
 
-from domain.services.schemas.label import CategoryMappings, RGBColor, VisualizationInfo, VisualizationLabel
+from domain.services.schemas.label import (
+    CategoryMappings,
+    LabelInfo,
+    RGBColor,
+    VisualizationInfo,
+    VisualizationLabel,
+)
 from domain.services.schemas.processor import OutputData
-from runtime.webrtc.visualizer import DEFAULT_FALLBACK_COLOR, InferenceVisualizer
+from runtime.webrtc.visualizer import (
+    DEFAULT_FALLBACK_COLOR,
+    CategoryResolver,
+    InferenceVisualizer,
+    generate_deterministic_color,
+)
 
 
 @pytest.fixture
@@ -28,9 +39,11 @@ def fxt_visualizer() -> InferenceVisualizer:
     with patch("runtime.webrtc.visualizer.get_settings") as mock_get_settings:
         mock_get_settings.return_value.visualize_masks = True
         mock_get_settings.return_value.visualize_boxes = False
+        mock_get_settings.return_value.visualize_labels = False
         mock_get_settings.return_value.mask_alpha = 1.0
         mock_get_settings.return_value.mask_outline_thickness = 0
         mock_get_settings.return_value.box_thickness = 2
+        mock_get_settings.return_value.label_font_scale = 0.5
         yield InferenceVisualizer(enable_visualization=True)
 
 
@@ -40,9 +53,11 @@ def fxt_visualizer_boxes_only() -> InferenceVisualizer:
     with patch("runtime.webrtc.visualizer.get_settings") as mock_get_settings:
         mock_get_settings.return_value.visualize_masks = False
         mock_get_settings.return_value.visualize_boxes = True
+        mock_get_settings.return_value.visualize_labels = False
         mock_get_settings.return_value.mask_alpha = 1.0
         mock_get_settings.return_value.mask_outline_thickness = 0
         mock_get_settings.return_value.box_thickness = 2
+        mock_get_settings.return_value.label_font_scale = 0.5
         yield InferenceVisualizer(enable_visualization=True)
 
 
@@ -52,9 +67,25 @@ def fxt_visualizer_both() -> InferenceVisualizer:
     with patch("runtime.webrtc.visualizer.get_settings") as mock_get_settings:
         mock_get_settings.return_value.visualize_masks = True
         mock_get_settings.return_value.visualize_boxes = True
+        mock_get_settings.return_value.visualize_labels = False
         mock_get_settings.return_value.mask_alpha = 1.0
         mock_get_settings.return_value.mask_outline_thickness = 0
         mock_get_settings.return_value.box_thickness = 2
+        mock_get_settings.return_value.label_font_scale = 0.5
+        yield InferenceVisualizer(enable_visualization=True)
+
+
+@pytest.fixture
+def fxt_visualizer_boxes_with_labels() -> InferenceVisualizer:
+    """Visualizer configured to draw boxes with label captions."""
+    with patch("runtime.webrtc.visualizer.get_settings") as mock_get_settings:
+        mock_get_settings.return_value.visualize_masks = False
+        mock_get_settings.return_value.visualize_boxes = True
+        mock_get_settings.return_value.visualize_labels = True
+        mock_get_settings.return_value.mask_alpha = 1.0
+        mock_get_settings.return_value.mask_outline_thickness = 0
+        mock_get_settings.return_value.box_thickness = 2
+        mock_get_settings.return_value.label_font_scale = 0.5
         yield InferenceVisualizer(enable_visualization=True)
 
 
@@ -72,14 +103,17 @@ def _two_pixel_disjoint_masks(h: int, w: int) -> np.ndarray:
 
 
 def _make_vis_info(
-    *, category_id_to_label_id: dict[int, str], label_colors: dict[str, tuple[int, int, int]]
+    *,
+    category_id_to_label_id: dict[int, str],
+    label_colors: dict[str, tuple[int, int, int]],
+    label_names: dict[str, str] | None = None,
 ) -> VisualizationInfo:
     return VisualizationInfo(
         label_colors=[
             VisualizationLabel(
                 id=UUID(label_id),
                 color=RGBColor(*rgb),
-                object_name=None,
+                object_name=(label_names or {}).get(label_id),
             )
             for label_id, rgb in label_colors.items()
         ],
@@ -140,7 +174,7 @@ def test_visualize_resolves_color_per_mask(
 
     if isinstance(expected, str) and expected.startswith("deterministic:"):
         category_id = int(expected.split(":", 1)[1])
-        expected_color = fxt_visualizer._generate_deterministic_color(category_id)
+        expected_color = generate_deterministic_color(category_id)
     else:
         expected_color = expected
 
@@ -296,7 +330,7 @@ def test_visualize_box_with_unmapped_category_uses_deterministic_color(
 
     result = fxt_visualizer_boxes_only.visualize(output_data=output, visualization_info=vis_info)
 
-    expected_color = fxt_visualizer_boxes_only._generate_deterministic_color(42)
+    expected_color = generate_deterministic_color(42)
     assert tuple(result[10, 20].tolist()) == expected_color
 
 
@@ -367,21 +401,22 @@ def test_visualize_both_masks_and_boxes(fxt_visualizer_both: InferenceVisualizer
     assert tuple(result[80, 80].tolist()) == (0, 0, 0)
 
 
-def test_draw_boxes_method(fxt_visualizer_boxes_only: InferenceVisualizer, fxt_large_frame: np.ndarray) -> None:
+def test_box_renderer_draw(fxt_large_frame: np.ndarray) -> None:
+    from runtime.webrtc.visualizer import BoxRenderer
+
     label_id = "00000000-0000-0000-0000-000000000001"
-    label_colors = {label_id: (0, 255, 0)}
-    category_id_to_label_id = {0: label_id}
+    vis_info = _make_vis_info(
+        category_id_to_label_id={0: label_id},
+        label_colors={label_id: (0, 255, 0)},
+    )
+    resolver = CategoryResolver(vis_info)
+    renderer = BoxRenderer(box_thickness=2, visualize_labels=False, label_font_scale=0.5, resolver=resolver)
 
     boxes = np.array([[20, 20, 40, 40]], dtype=np.float32)
     labels = np.array([0], dtype=np.int64)
+    prediction: dict[str, np.ndarray] = {"pred_boxes": boxes, "pred_labels": labels}
 
-    result = fxt_visualizer_boxes_only._draw_boxes(
-        fxt_large_frame.copy(),
-        boxes,
-        labels,
-        label_colors,
-        category_id_to_label_id,
-    )
+    result = renderer.draw(fxt_large_frame.copy(), prediction, labels)
 
     # Check box edge is drawn
     assert tuple(result[20, 30].tolist()) == (0, 255, 0)
@@ -408,3 +443,176 @@ def test_visualize_prediction_with_only_boxes_no_masks(
 
     # Box should be drawn
     assert tuple(result[10, 20].tolist()) == (0, 0, 255)
+
+
+# --- Label caption tests ---
+
+
+def test_visualize_draws_label_caption_with_name_and_score(
+    fxt_visualizer_boxes_with_labels: InferenceVisualizer,
+) -> None:
+    """Label name and confidence score are rendered above the bounding box."""
+    frame = np.zeros((200, 200, 3), dtype=np.uint8)
+    label_id = "00000000-0000-0000-0000-000000000001"
+    vis_info = _make_vis_info(
+        category_id_to_label_id={0: label_id},
+        label_colors={label_id: (255, 0, 0)},
+        label_names={label_id: "Cat"},
+    )
+
+    boxes = np.array([[20, 40, 80, 100, 0.95]], dtype=np.float32)
+    labels = np.array([0], dtype=np.int64)
+    output = OutputData(frame=frame, results=[{"pred_boxes": boxes, "pred_labels": labels}])
+
+    result = fxt_visualizer_boxes_with_labels.visualize(output_data=output, visualization_info=vis_info)
+
+    # The region above the box (y < 40) should have non-zero pixels from the caption
+    caption_region = result[0:40, 20:80]
+    assert caption_region.any(), "Expected label caption pixels above the bounding box"
+
+
+def test_visualize_draws_score_only_when_no_label_name(
+    fxt_visualizer_boxes_with_labels: InferenceVisualizer,
+) -> None:
+    """When object_name is not set, only the confidence score is rendered."""
+    frame = np.zeros((200, 200, 3), dtype=np.uint8)
+    label_id = "00000000-0000-0000-0000-000000000001"
+    vis_info = _make_vis_info(
+        category_id_to_label_id={0: label_id},
+        label_colors={label_id: (0, 255, 0)},
+        # no label_names -> object_name is None
+    )
+
+    boxes = np.array([[20, 40, 80, 100, 0.88]], dtype=np.float32)
+    labels = np.array([0], dtype=np.int64)
+    output = OutputData(frame=frame, results=[{"pred_boxes": boxes, "pred_labels": labels}])
+
+    result = fxt_visualizer_boxes_with_labels.visualize(output_data=output, visualization_info=vis_info)
+
+    # Score-only caption should still appear above the box
+    caption_region = result[0:40, 20:80]
+    assert caption_region.any(), "Expected score caption pixels above the bounding box"
+
+
+def test_visualize_no_caption_when_labels_disabled(
+    fxt_visualizer_boxes_only: InferenceVisualizer, fxt_large_frame: np.ndarray
+) -> None:
+    """No caption is drawn when visualize_labels is False."""
+    label_id = "00000000-0000-0000-0000-000000000001"
+    vis_info = _make_vis_info(
+        category_id_to_label_id={0: label_id},
+        label_colors={label_id: (255, 0, 0)},
+        label_names={label_id: "Dog"},
+    )
+
+    boxes = np.array([[20, 30, 80, 80, 0.90]], dtype=np.float32)
+    labels = np.array([0], dtype=np.int64)
+    output = OutputData(frame=fxt_large_frame, results=[{"pred_boxes": boxes, "pred_labels": labels}])
+
+    result = fxt_visualizer_boxes_only.visualize(output_data=output, visualization_info=vis_info)
+
+    # Area above the box should remain black (no caption)
+    caption_region = result[0:28, 20:80]
+    assert not caption_region.any(), "Expected no caption pixels when visualize_labels is disabled"
+
+
+def test_visualize_no_caption_for_box_without_score_or_name(
+    fxt_visualizer_boxes_with_labels: InferenceVisualizer,
+) -> None:
+    """No caption is drawn when there is no score column and no label name."""
+    frame = np.zeros((200, 200, 3), dtype=np.uint8)
+    vis_info = _make_vis_info(category_id_to_label_id={}, label_colors={})
+
+    # Box with no score column (4 cols), unmapped category -> no name either
+    boxes = np.array([[20, 40, 80, 100]], dtype=np.float32)
+    labels = np.array([99], dtype=np.int64)
+    output = OutputData(frame=frame, results=[{"pred_boxes": boxes, "pred_labels": labels}])
+
+    result = fxt_visualizer_boxes_with_labels.visualize(output_data=output, visualization_info=vis_info)
+
+    # Caption region should be empty (no name, no score)
+    caption_region = result[0:38, 20:80]
+    assert not caption_region.any(), "Expected no caption when neither name nor score is available"
+
+
+def test_visualize_draws_label_name_only_without_score(
+    fxt_visualizer_boxes_with_labels: InferenceVisualizer,
+) -> None:
+    """Label name is rendered even when there is no score column."""
+    frame = np.zeros((200, 200, 3), dtype=np.uint8)
+    label_id = "00000000-0000-0000-0000-000000000001"
+    vis_info = _make_vis_info(
+        category_id_to_label_id={0: label_id},
+        label_colors={label_id: (0, 0, 255)},
+        label_names={label_id: "Bike"},
+    )
+
+    # Box without score column (4 cols)
+    boxes = np.array([[20, 40, 80, 100]], dtype=np.float32)
+    labels = np.array([0], dtype=np.int64)
+    output = OutputData(frame=frame, results=[{"pred_boxes": boxes, "pred_labels": labels}])
+
+    result = fxt_visualizer_boxes_with_labels.visualize(output_data=output, visualization_info=vis_info)
+
+    caption_region = result[0:40, 20:80]
+    assert caption_region.any(), "Expected label-name-only caption above bounding box"
+
+
+# --- CategoryResolver tests ---
+
+
+class TestCategoryResolver:
+    def test_resolve_mapped_category_returns_color_and_name(self) -> None:
+        label_id = "00000000-0000-0000-0000-000000000001"
+        vis_info = _make_vis_info(
+            category_id_to_label_id={0: label_id},
+            label_colors={label_id: (255, 0, 0)},
+            label_names={label_id: "Cat"},
+        )
+        resolver = CategoryResolver(vis_info)
+
+        info = resolver.resolve(0)
+
+        assert info.color == (255, 0, 0)
+        assert info.name == "Cat"
+
+    def test_resolve_mapped_category_without_name(self) -> None:
+        label_id = "00000000-0000-0000-0000-000000000001"
+        vis_info = _make_vis_info(
+            category_id_to_label_id={0: label_id},
+            label_colors={label_id: (0, 255, 0)},
+        )
+        resolver = CategoryResolver(vis_info)
+
+        info = resolver.resolve(0)
+
+        assert info.color == (0, 255, 0)
+        assert info.name is None
+
+    def test_resolve_unmapped_category_returns_deterministic_color(self) -> None:
+        resolver = CategoryResolver(None)
+
+        info = resolver.resolve(7)
+
+        assert info.color == generate_deterministic_color(7)
+        assert info.name is None
+
+    def test_resolve_none_category_returns_fallback(self) -> None:
+        resolver = CategoryResolver(None)
+
+        info = resolver.resolve(None)
+
+        assert info.color == DEFAULT_FALLBACK_COLOR
+        assert info.name is None
+
+    def test_extract_category_id_valid(self) -> None:
+        labels = np.array([3, 5], dtype=np.int64)
+        assert CategoryResolver.extract_category_id(labels, 0) == 3
+        assert CategoryResolver.extract_category_id(labels, 1) == 5
+
+    def test_extract_category_id_out_of_bounds(self) -> None:
+        labels = np.array([3], dtype=np.int64)
+        assert CategoryResolver.extract_category_id(labels, 5) is None
+
+    def test_extract_category_id_none_labels(self) -> None:
+        assert CategoryResolver.extract_category_id(None, 0) is None

--- a/application/backend/tests/unit/runtime/webrtc/test_visualizer.py
+++ b/application/backend/tests/unit/runtime/webrtc/test_visualizer.py
@@ -572,8 +572,8 @@ class TestCategoryResolver:
 
         info = resolver.resolve(0)
 
-        assert info.color == (255, 0, 0)
-        assert info.name == "Cat"
+        assert info.color.to_tuple() == (255, 0, 0)
+        assert info.object_name == "Cat"
 
     def test_resolve_mapped_category_without_name(self) -> None:
         label_id = "00000000-0000-0000-0000-000000000001"
@@ -585,24 +585,24 @@ class TestCategoryResolver:
 
         info = resolver.resolve(0)
 
-        assert info.color == (0, 255, 0)
-        assert info.name is None
+        assert info.color.to_tuple() == (0, 255, 0)
+        assert info.object_name is None
 
     def test_resolve_unmapped_category_returns_deterministic_color(self) -> None:
         resolver = CategoryResolver(None)
 
         info = resolver.resolve(7)
 
-        assert info.color == generate_deterministic_color(7)
-        assert info.name is None
+        assert info.color.to_tuple() == generate_deterministic_color(7)
+        assert info.object_name is None
 
     def test_resolve_none_category_returns_fallback(self) -> None:
         resolver = CategoryResolver(None)
 
         info = resolver.resolve(None)
 
-        assert info.color == DEFAULT_FALLBACK_COLOR
-        assert info.name is None
+        assert info.color.to_tuple() == DEFAULT_FALLBACK_COLOR
+        assert info.object_name is None
 
     def test_extract_category_id_valid(self) -> None:
         labels = np.array([3, 5], dtype=np.int64)

--- a/application/backend/tests/unit/runtime/webrtc/test_visualizer.py
+++ b/application/backend/tests/unit/runtime/webrtc/test_visualizer.py
@@ -9,7 +9,6 @@ import pytest
 
 from domain.services.schemas.label import (
     CategoryMappings,
-    LabelInfo,
     RGBColor,
     VisualizationInfo,
     VisualizationLabel,


### PR DESCRIPTION
## Description

Bounding boxes now show label names and confidence scores. 
The visualizer was also refactored:
 - `CategoryResolver` owns the category→label→metadata lookup
 -  `OverlayRenderer` - a renderer protocol with `MaskRenderer` and `BoxRenderer` implementations instead of everything living in one class.

## Type of Change

- [x] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [x] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance