### PR TITLE
use settings to generate thumbnail with better quality

### DIFF
--- a/application/backend/app/runtime/core/components/readers/image_folder_reader.py
+++ b/application/backend/app/runtime/core/components/readers/image_folder_reader.py
@@ -54,8 +54,8 @@ class ImageFolderReader(StreamReader):
 
         Args:
             image_path: Path to the image file
-            max_size: Maximum dimension for thumbnail
-            jpeg_quality: JPEG quality 0-100
+            max_size: Maximum dimension for thumbnail. If None, use the configured setting.
+            jpeg_quality: JPEG quality 0-100. If None, use the configured setting.
         Returns:
             Base64-encoded data URI string or None if generation fails
         """

--- a/application/backend/app/runtime/core/components/readers/image_folder_reader.py
+++ b/application/backend/app/runtime/core/components/readers/image_folder_reader.py
@@ -47,9 +47,19 @@ class ImageFolderReader(StreamReader):
         return True
 
     @staticmethod
-    def _generate_thumbnail(image_path: Path, max_size: int = 150) -> str | None:
-        """Generate a base64-encoded thumbnail for an image."""
-        return generate_image_thumbnail(image_path, max_size=max_size, jpeg_quality=80)
+    def _generate_thumbnail(
+        image_path: Path, max_size: int | None = None, jpeg_quality: int | None = None
+    ) -> str | None:
+        """Generate a base64-encoded thumbnail for an image.
+
+        Args:
+            image_path: Path to the image file
+            max_size: Maximum dimension for thumbnail
+            jpeg_quality: JPEG quality 0-100
+        Returns:
+            Base64-encoded data URI string or None if generation fails
+        """
+        return generate_image_thumbnail(image_path, max_size=max_size, jpeg_quality=jpeg_quality)
 
     def _get_image_files(self, folder_path: Path) -> list[Path]:
         """

--- a/application/backend/app/runtime/core/components/readers/image_folder_reader.py
+++ b/application/backend/app/runtime/core/components/readers/image_folder_reader.py
@@ -46,21 +46,6 @@ class ImageFolderReader(StreamReader):
         """
         return True
 
-    @staticmethod
-    def _generate_thumbnail(
-        image_path: Path, max_size: int | None = None, jpeg_quality: int | None = None
-    ) -> str | None:
-        """Generate a base64-encoded thumbnail for an image.
-
-        Args:
-            image_path: Path to the image file
-            max_size: Maximum dimension for thumbnail. If None, use the configured setting.
-            jpeg_quality: JPEG quality 0-100. If None, use the configured setting.
-        Returns:
-            Base64-encoded data URI string or None if generation fails
-        """
-        return generate_image_thumbnail(image_path, max_size=max_size, jpeg_quality=jpeg_quality)
-
     def _get_image_files(self, folder_path: Path) -> list[Path]:
         """
         Filter and collect supported image files from the given folder.
@@ -110,7 +95,7 @@ class ImageFolderReader(StreamReader):
 
             # Pre-generate thumbnails for first page (optimization)
             for idx, path in enumerate(self._image_paths[:30]):
-                thumbnail = self._generate_thumbnail(path)
+                thumbnail = generate_image_thumbnail(path)
                 if thumbnail:
                     self._thumbnail_cache[idx] = thumbnail
 
@@ -198,7 +183,7 @@ class ImageFolderReader(StreamReader):
             if idx in self._thumbnail_cache:
                 thumbnail = self._thumbnail_cache[idx]
             else:
-                thumbnail = self._generate_thumbnail(image_path)
+                thumbnail = generate_image_thumbnail(image_path)
                 if thumbnail is not None:
                     with self._lock:
                         self._thumbnail_cache[idx] = thumbnail

--- a/application/backend/app/runtime/services/image_thumbnail.py
+++ b/application/backend/app/runtime/services/image_thumbnail.py
@@ -23,8 +23,8 @@ def generate_image_thumbnail(
 
     Args:
         image_path: Path to the image file
-        max_size: Maximum dimension for thumbnail
-        jpeg_quality: JPEG quality 0-100
+        max_size: Maximum dimension for thumbnail. If None, use the configured setting.
+        jpeg_quality: JPEG quality 0-100. If None, use the configured setting.
 
     Returns:
         Base64-encoded data URI string or None if generation fails
@@ -39,9 +39,17 @@ def generate_image_thumbnail(
             return None
 
         height, width = image.shape[:2]
-        scale = min(max_size / width, max_size / height)
-        new_width, new_height = int(width * scale), int(height * scale)
-        thumbnail = cv2.resize(image, (new_width, new_height), interpolation=cv2.INTER_AREA)
+        # Cap scale at 1.0 to prevent upscaling small images
+        scale = min(1.0, max_size / width, max_size / height)
+        # Ensure dimensions are at least 1px to avoid cv2.resize errors
+        new_width = max(1, int(width * scale))
+        new_height = max(1, int(height * scale))
+
+        # Only resize if needed (scale < 1.0)
+        if scale < 1.0:
+            thumbnail = cv2.resize(image, (new_width, new_height), interpolation=cv2.INTER_AREA)
+        else:
+            thumbnail = image
 
         success, buffer = cv2.imencode(".jpg", thumbnail, [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality])
         if not success:

--- a/application/backend/app/runtime/services/image_thumbnail.py
+++ b/application/backend/app/runtime/services/image_thumbnail.py
@@ -7,11 +7,32 @@ from pathlib import Path
 
 import cv2
 
+from settings import get_settings
+
 logger = logging.getLogger(__name__)
 
+settings = get_settings()
 
-def generate_image_thumbnail(image_path: Path, max_size: int = 150, jpeg_quality: int = 80) -> str | None:
-    """Generate a base64-encoded JPEG thumbnail for an image file."""
+
+def generate_image_thumbnail(
+    image_path: Path,
+    max_size: int | None = None,
+    jpeg_quality: int | None = None,
+) -> str | None:
+    """Generate a base64-encoded JPEG thumbnail for an image file.
+
+    Args:
+        image_path: Path to the image file
+        max_size: Maximum dimension for thumbnail
+        jpeg_quality: JPEG quality 0-100
+
+    Returns:
+        Base64-encoded data URI string or None if generation fails
+    """
+    if max_size is None:
+        max_size = settings.thumbnail_max_dimension
+    if jpeg_quality is None:
+        jpeg_quality = settings.thumbnail_jpeg_quality
     try:
         image = cv2.imread(str(image_path))
         if image is None:

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -113,11 +113,13 @@ class Settings(BaseSettings):
     supported_extensions: set[str] = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
 
     # Thumbnail generation
-    thumbnail_max_dimension: int = 300
-    thumbnail_line_thickness_ratio: float = 0.005  # 0.5% of smaller image dimension
-    thumbnail_min_line_thickness: int = 2
-    thumbnail_fill_opacity: float = 0.5  # 50% opacity for annotation fill
-    thumbnail_jpeg_quality: int = 85
+    thumbnail_max_dimension: int = Field(default=300, ge=0, alias="THUMBNAIL_MAX_DIMENSION")
+    thumbnail_line_thickness_ratio: float = Field(
+        default=0.005, ge=0.0, le=1.0, alias="THUMBNAIL_LINE_THICKNESS_RATIO"
+    )  # 0.5% of smaller image dimension
+    thumbnail_min_line_thickness: int = Field(default=2, ge=0, alias="THUMBNAIL_MIN_LINE_THICKNESS")
+    thumbnail_fill_opacity: float = Field(default=0.5, ge=0.0, le=1.0, alias="THUMBNAIL_FILL_OPACITY")
+    thumbnail_jpeg_quality: int = Field(default=85, ge=0, le=100, alias="THUMBNAIL_JPEG_QUALITY")
 
     # Processor configuration
     processor_batch_size: int = Field(default=1, alias="PROCESSOR_BATCH_SIZE")

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -118,7 +118,9 @@ class Settings(BaseSettings):
         default=0.005, ge=0.0, le=1.0, alias="THUMBNAIL_LINE_THICKNESS_RATIO"
     )  # 0.5% of smaller image dimension
     thumbnail_min_line_thickness: int = Field(default=2, ge=0, alias="THUMBNAIL_MIN_LINE_THICKNESS")
-    thumbnail_fill_opacity: float = Field(default=0.5, ge=0.0, le=1.0, alias="THUMBNAIL_FILL_OPACITY")
+    thumbnail_fill_opacity: float = Field(
+        default=0.5, ge=0.0, le=1.0, alias="THUMBNAIL_FILL_OPACITY"
+    )  # 50% opacity for annotation fill
     thumbnail_jpeg_quality: int = Field(default=85, ge=0, le=100, alias="THUMBNAIL_JPEG_QUALITY")
 
     # Processor configuration

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -113,7 +113,7 @@ class Settings(BaseSettings):
     supported_extensions: set[str] = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
 
     # Thumbnail generation
-    thumbnail_max_dimension: int = Field(default=300, ge=0, alias="THUMBNAIL_MAX_DIMENSION")
+    thumbnail_max_dimension: int = Field(default=400, ge=0, alias="THUMBNAIL_MAX_DIMENSION")
     thumbnail_line_thickness_ratio: float = Field(
         default=0.005, ge=0.0, le=1.0, alias="THUMBNAIL_LINE_THICKNESS_RATIO"
     )  # 0.5% of smaller image dimension
@@ -121,7 +121,7 @@ class Settings(BaseSettings):
     thumbnail_fill_opacity: float = Field(
         default=0.5, ge=0.0, le=1.0, alias="THUMBNAIL_FILL_OPACITY"
     )  # 50% opacity for annotation fill
-    thumbnail_jpeg_quality: int = Field(default=85, ge=0, le=100, alias="THUMBNAIL_JPEG_QUALITY")
+    thumbnail_jpeg_quality: int = Field(default=90, ge=0, le=100, alias="THUMBNAIL_JPEG_QUALITY")
 
     # Processor configuration
     processor_batch_size: int = Field(default=1, alias="PROCESSOR_BATCH_SIZE")

--- a/application/backend/tests/unit/domain/services/test_thumbnails.py
+++ b/application/backend/tests/unit/domain/services/test_thumbnails.py
@@ -44,16 +44,24 @@ class TestResizeFrame:
         resized = _resize_frame_to_thumbnail_size(frame)
 
         assert max(resized.shape[:2]) == settings.thumbnail_max_dimension
-        assert resized.shape[0] == 240
-        assert resized.shape[1] == 300
+        # With max_dimension and 1000x800 frame: scale = max_dim/1000
+        # Expected dimensions: max_dim x (800 * scale)
+        expected_width = settings.thumbnail_max_dimension
+        expected_height = int(800 * (settings.thumbnail_max_dimension / 1000))
+        assert resized.shape[0] == expected_height
+        assert resized.shape[1] == expected_width
 
     def test_resize_tall_frame(self):
         frame = create_test_frame(width=600, height=1200)
         resized = _resize_frame_to_thumbnail_size(frame)
 
         assert max(resized.shape[:2]) == settings.thumbnail_max_dimension
-        assert resized.shape[0] == 300
-        assert resized.shape[1] == 150
+        # With max_dimension and 600x1200 frame: scale = max_dim/1200
+        # Expected dimensions: (600 * scale) x max_dim
+        expected_height = settings.thumbnail_max_dimension
+        expected_width = int(600 * (settings.thumbnail_max_dimension / 1200))
+        assert resized.shape[0] == expected_height
+        assert resized.shape[1] == expected_width
 
     def test_no_resize_small_frame(self):
         frame = create_test_frame(width=300, height=200)

--- a/application/backend/tests/unit/runtime/core/components/readers/test_image_folder_reader.py
+++ b/application/backend/tests/unit/runtime/core/components/readers/test_image_folder_reader.py
@@ -314,10 +314,10 @@ class TestImageFolderReaderListFrames:
         reader.connect()
 
         # First call should use pre-generated cache
-        with patch.object(ImageFolderReader, "_generate_thumbnail") as mock_gen:
+        with patch("runtime.core.components.readers.image_folder_reader.generate_image_thumbnail") as mock_gen:
             result = reader.list_frames(offset=0, limit=3)
             assert len(result.frames) == 3
-            # Should not call _generate_thumbnail since thumbnails are cached
+            # Should not call generate_image_thumbnail since thumbnails are cached
             mock_gen.assert_not_called()
 
     def test_list_frames_generates_uncached(self, tmp_path):
@@ -366,67 +366,3 @@ class TestImageFolderReaderContextManager:
 
         # After exiting context, close should have been called
         assert reader._image_paths == []
-
-
-class TestImageFolderReaderThumbnailGeneration:
-    def test_generate_thumbnail_valid_image(self, tmp_path):
-        """Test thumbnail generation for valid image."""
-        img_path = tmp_path / "test.jpg"
-        cv2.imwrite(str(img_path), np.zeros((200, 200, 3), dtype=np.uint8))
-
-        thumbnail = ImageFolderReader._generate_thumbnail(img_path)
-
-        assert thumbnail is not None
-        assert isinstance(thumbnail, str)
-        assert len(thumbnail) > 0  # base64 encoded string
-
-    def test_generate_thumbnail_invalid_image(self, tmp_path):
-        """Test thumbnail generation for invalid image."""
-        img_path = tmp_path / "invalid.jpg"
-        img_path.write_bytes(b"not an image")
-
-        thumbnail = ImageFolderReader._generate_thumbnail(img_path)
-
-        assert thumbnail is None
-
-    def test_generate_thumbnail_nonexistent_file(self):
-        """Test thumbnail generation for non-existent file."""
-        thumbnail = ImageFolderReader._generate_thumbnail(Path("/nonexistent/file.jpg"))
-
-        assert thumbnail is None
-
-    def test_generate_thumbnail_uses_settings_defaults(self, tmp_path, monkeypatch):
-        """Test that thumbnail generation uses settings defaults when no parameters provided."""
-        img_path = tmp_path / "test.jpg"
-        cv2.imwrite(str(img_path), np.zeros((200, 200, 3), dtype=np.uint8))
-
-        # Mock the generate_image_thumbnail function to verify it's called with correct params
-        mock_generate = Mock(return_value="mock_thumbnail")
-        monkeypatch.setattr(
-            "runtime.core.components.readers.image_folder_reader.generate_image_thumbnail",
-            mock_generate,
-        )
-
-        # Call without parameters - should use settings defaults
-        result = ImageFolderReader._generate_thumbnail(img_path)
-
-        assert result == "mock_thumbnail"
-        mock_generate.assert_called_once_with(img_path, max_size=None, jpeg_quality=None)
-
-    def test_generate_thumbnail_forwards_custom_parameters(self, tmp_path, monkeypatch):
-        """Test that custom max_size and jpeg_quality parameters are properly forwarded."""
-        img_path = tmp_path / "test.jpg"
-        cv2.imwrite(str(img_path), np.zeros((200, 200, 3), dtype=np.uint8))
-
-        # Mock the generate_image_thumbnail function
-        mock_generate = Mock(return_value="mock_thumbnail")
-        monkeypatch.setattr(
-            "runtime.core.components.readers.image_folder_reader.generate_image_thumbnail",
-            mock_generate,
-        )
-
-        # Call with custom parameters
-        result = ImageFolderReader._generate_thumbnail(img_path, max_size=100, jpeg_quality=90)
-
-        assert result == "mock_thumbnail"
-        mock_generate.assert_called_once_with(img_path, max_size=100, jpeg_quality=90)

--- a/application/backend/tests/unit/runtime/core/components/readers/test_image_folder_reader.py
+++ b/application/backend/tests/unit/runtime/core/components/readers/test_image_folder_reader.py
@@ -394,3 +394,39 @@ class TestImageFolderReaderThumbnailGeneration:
         thumbnail = ImageFolderReader._generate_thumbnail(Path("/nonexistent/file.jpg"))
 
         assert thumbnail is None
+
+    def test_generate_thumbnail_uses_settings_defaults(self, tmp_path, monkeypatch):
+        """Test that thumbnail generation uses settings defaults when no parameters provided."""
+        img_path = tmp_path / "test.jpg"
+        cv2.imwrite(str(img_path), np.zeros((200, 200, 3), dtype=np.uint8))
+
+        # Mock the generate_image_thumbnail function to verify it's called with correct params
+        mock_generate = Mock(return_value="mock_thumbnail")
+        monkeypatch.setattr(
+            "runtime.core.components.readers.image_folder_reader.generate_image_thumbnail",
+            mock_generate,
+        )
+
+        # Call without parameters - should use settings defaults
+        result = ImageFolderReader._generate_thumbnail(img_path)
+
+        assert result == "mock_thumbnail"
+        mock_generate.assert_called_once_with(img_path, max_size=None, jpeg_quality=None)
+
+    def test_generate_thumbnail_forwards_custom_parameters(self, tmp_path, monkeypatch):
+        """Test that custom max_size and jpeg_quality parameters are properly forwarded."""
+        img_path = tmp_path / "test.jpg"
+        cv2.imwrite(str(img_path), np.zeros((200, 200, 3), dtype=np.uint8))
+
+        # Mock the generate_image_thumbnail function
+        mock_generate = Mock(return_value="mock_thumbnail")
+        monkeypatch.setattr(
+            "runtime.core.components.readers.image_folder_reader.generate_image_thumbnail",
+            mock_generate,
+        )
+
+        # Call with custom parameters
+        result = ImageFolderReader._generate_thumbnail(img_path, max_size=100, jpeg_quality=90)
+
+        assert result == "mock_thumbnail"
+        mock_generate.assert_called_once_with(img_path, max_size=100, jpeg_quality=90)

--- a/application/backend/tests/unit/runtime/services/test_image_thumbnail.py
+++ b/application/backend/tests/unit/runtime/services/test_image_thumbnail.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import cv2
+import numpy as np
+import pytest
+
+from runtime.services.image_thumbnail import generate_image_thumbnail
+
+
+@pytest.fixture
+def test_image(tmp_path):
+    """Create a test image."""
+    img_path = tmp_path / "test.jpg"
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    img[:, :] = [100, 150, 200]  # BGR color
+    cv2.imwrite(str(img_path), img)
+    return img_path
+
+
+class TestGenerateImageThumbnail:
+    def test_generate_thumbnail_valid_image(self, test_image):
+        """Test thumbnail generation for a valid image."""
+        thumbnail = generate_image_thumbnail(test_image)
+
+        assert thumbnail is not None
+        assert isinstance(thumbnail, str)
+        assert thumbnail.startswith("data:image/jpeg;base64,")
+        assert len(thumbnail) > 50  # Has actual content
+
+    def test_generate_thumbnail_nonexistent_file(self):
+        """Test thumbnail generation for non-existent file."""
+        thumbnail = generate_image_thumbnail(Path("/nonexistent/file.jpg"))
+
+        assert thumbnail is None
+
+    def test_generate_thumbnail_invalid_image(self, tmp_path):
+        """Test thumbnail generation for invalid image data."""
+        invalid_path = tmp_path / "invalid.jpg"
+        invalid_path.write_bytes(b"not an image")
+
+        thumbnail = generate_image_thumbnail(invalid_path)
+
+        assert thumbnail is None
+
+    def test_generate_thumbnail_uses_settings_defaults(self, test_image, monkeypatch):
+        """Test that settings defaults are used when no parameters provided."""
+        # Mock settings
+        mock_settings = Mock()
+        mock_settings.thumbnail_max_dimension = 300
+        mock_settings.thumbnail_jpeg_quality = 85
+
+        monkeypatch.setattr("runtime.services.image_thumbnail.settings", mock_settings)
+
+        with patch("cv2.resize") as mock_resize, patch("cv2.imencode") as mock_encode:
+            # Setup mocks
+            mock_resize.return_value = np.zeros((150, 150, 3), dtype=np.uint8)
+            mock_encode.return_value = (True, np.array([1, 2, 3], dtype=np.uint8))
+
+            # Call with no parameters
+            generate_image_thumbnail(test_image)
+
+            # Verify imencode was called with settings.thumbnail_jpeg_quality
+            mock_encode.assert_called_once()
+            call_args = mock_encode.call_args[0]
+            assert call_args[0] == ".jpg"
+            assert call_args[2] == [cv2.IMWRITE_JPEG_QUALITY, 85]
+
+    def test_generate_thumbnail_respects_custom_max_size(self, test_image):
+        """Test that custom max_size is respected."""
+        thumbnail_small = generate_image_thumbnail(test_image, max_size=50)
+        thumbnail_large = generate_image_thumbnail(test_image, max_size=200)
+
+        assert thumbnail_small is not None
+        assert thumbnail_large is not None
+        # Smaller max_size should result in smaller base64 string
+        assert len(thumbnail_small) < len(thumbnail_large)
+
+    def test_generate_thumbnail_respects_custom_jpeg_quality(self, test_image):
+        """Test that custom jpeg_quality is respected."""
+        thumbnail_low = generate_image_thumbnail(test_image, jpeg_quality=50)
+        thumbnail_high = generate_image_thumbnail(test_image, jpeg_quality=95)
+
+        assert thumbnail_low is not None
+        assert thumbnail_high is not None
+        # Higher quality should result in larger base64 string
+        assert len(thumbnail_low) < len(thumbnail_high)
+
+    def test_generate_thumbnail_custom_parameters_override_settings(self, test_image, monkeypatch):
+        """Test that custom parameters override settings defaults."""
+        # Mock settings with different values
+        mock_settings = Mock()
+        mock_settings.thumbnail_max_dimension = 300
+        mock_settings.thumbnail_jpeg_quality = 85
+
+        monkeypatch.setattr("runtime.services.image_thumbnail.settings", mock_settings)
+
+        with patch("cv2.resize") as mock_resize, patch("cv2.imencode") as mock_encode:
+            # Setup mocks
+            mock_resize.return_value = np.zeros((100, 100, 3), dtype=np.uint8)
+            mock_encode.return_value = (True, np.array([1, 2, 3], dtype=np.uint8))
+
+            # Call with custom parameters
+            generate_image_thumbnail(test_image, max_size=100, jpeg_quality=60)
+
+            # Verify imencode was called with custom jpeg_quality, not settings default
+            mock_encode.assert_called_once()
+            call_args = mock_encode.call_args[0]
+            assert call_args[2] == [cv2.IMWRITE_JPEG_QUALITY, 60]
+
+    def test_generate_thumbnail_resizes_large_image(self, tmp_path):
+        """Test that large images are resized according to max_size."""
+        large_img_path = tmp_path / "large.jpg"
+        large_img = np.zeros((1000, 1000, 3), dtype=np.uint8)
+        cv2.imwrite(str(large_img_path), large_img)
+
+        thumbnail = generate_image_thumbnail(large_img_path, max_size=200)
+
+        assert thumbnail is not None
+        # Decode and verify size
+        import base64
+
+        img_data = base64.b64decode(thumbnail.split(",")[1])
+        img_array = np.frombuffer(img_data, dtype=np.uint8)
+        decoded_img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+
+        # Should be resized to max_size
+        assert max(decoded_img.shape[:2]) <= 200
+
+    def test_generate_thumbnail_preserves_aspect_ratio(self, tmp_path):
+        """Test that aspect ratio is preserved when resizing."""
+        rect_img_path = tmp_path / "rectangular.jpg"
+        # Create a 400x200 image (2:1 aspect ratio)
+        rect_img = np.zeros((200, 400, 3), dtype=np.uint8)
+        cv2.imwrite(str(rect_img_path), rect_img)
+
+        thumbnail = generate_image_thumbnail(rect_img_path, max_size=100)
+
+        assert thumbnail is not None
+        # Decode and check aspect ratio
+        import base64
+
+        img_data = base64.b64decode(thumbnail.split(",")[1])
+        img_array = np.frombuffer(img_data, dtype=np.uint8)
+        decoded_img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+
+        height, width = decoded_img.shape[:2]
+        aspect_ratio = width / height
+        # Should maintain approximately 2:1 aspect ratio
+        assert 1.9 < aspect_ratio < 2.1
+
+    def test_generate_thumbnail_no_upscaling_small_image(self, tmp_path):
+        """Test that small images are not upscaled beyond their original size."""
+        small_img_path = tmp_path / "small.jpg"
+        # Create a 50x50 image (smaller than max_size default of 300)
+        small_img = np.zeros((50, 50, 3), dtype=np.uint8)
+        small_img[:, :] = [100, 150, 200]
+        cv2.imwrite(str(small_img_path), small_img)
+
+        thumbnail = generate_image_thumbnail(small_img_path, max_size=300)
+
+        assert thumbnail is not None
+        # Decode and verify it wasn't upscaled
+        import base64
+
+        img_data = base64.b64decode(thumbnail.split(",")[1])
+        img_array = np.frombuffer(img_data, dtype=np.uint8)
+        decoded_img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+
+        height, width = decoded_img.shape[:2]
+        # Should remain at original size, not upscaled to 300x300
+        assert height <= 50
+        assert width <= 50
+
+    def test_generate_thumbnail_very_thin_image(self, tmp_path):
+        """Test that very thin images don't cause errors due to 0-dimension rounding."""
+        thin_img_path = tmp_path / "thin.jpg"
+        # Create a 1x1000 image (very thin)
+        thin_img = np.zeros((1000, 1, 3), dtype=np.uint8)
+        thin_img[:, :] = [100, 150, 200]
+        cv2.imwrite(str(thin_img_path), thin_img)
+
+        # This should not raise an error even with aggressive downscaling
+        thumbnail = generate_image_thumbnail(thin_img_path, max_size=100)
+
+        assert thumbnail is not None
+        # Decode and verify dimensions are at least 1px
+        import base64
+
+        img_data = base64.b64decode(thumbnail.split(",")[1])
+        img_array = np.frombuffer(img_data, dtype=np.uint8)
+        decoded_img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+
+        height, width = decoded_img.shape[:2]
+        # Both dimensions should be at least 1
+        assert height >= 1
+        assert width >= 1
+        # Longest dimension should be capped at max_size
+        assert max(height, width) <= 100
+
+    def test_generate_thumbnail_tiny_image(self, tmp_path):
+        """Test that tiny images (smaller than max_size) are not upscaled."""
+        tiny_img_path = tmp_path / "tiny.jpg"
+        # Create a 10x20 image
+        tiny_img = np.zeros((20, 10, 3), dtype=np.uint8)
+        tiny_img[:, :] = [100, 150, 200]
+        cv2.imwrite(str(tiny_img_path), tiny_img)
+
+        thumbnail = generate_image_thumbnail(tiny_img_path, max_size=300)
+
+        assert thumbnail is not None
+        # Decode and verify original size is preserved
+        import base64
+
+        img_data = base64.b64decode(thumbnail.split(",")[1])
+        img_array = np.frombuffer(img_data, dtype=np.uint8)
+        decoded_img = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+
+        height, width = decoded_img.shape[:2]
+        # Should maintain original dimensions
+        assert height == 20
+        assert width == 10


### PR DESCRIPTION
# Pull Request

## Description

Make thumbnail generation for sample dataset use parameters from settings
before:
<img width="385" height="482" alt="image" src="https://github.com/user-attachments/assets/09c97b53-fc0a-41ea-b0e0-78985edb698c" />

after:
<img width="382" height="587" alt="image" src="https://github.com/user-attachments/assets/aa61e843-84f2-41e6-a928-87303788b883" />

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
