### PR TITLE
refactor: require DeviceResolver injection in ModelFactory & cleanup logging

### DIFF
--- a/application/backend/app/main.py
+++ b/application/backend/app/main.py
@@ -55,6 +55,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         format=settings.log_format,
         force=True,
     )
+    # Suppress noise from aiortc when logging level is set to DEBUG
+    logging.getLogger("aiortc").setLevel(logging.INFO)
+
     logger.info(f"Starting {settings.app_name} application...")
     logger.info(settings.format_for_logging())
     run_db_migrations()

--- a/application/backend/app/runtime/components.py
+++ b/application/backend/app/runtime/components.py
@@ -11,7 +11,7 @@ from domain.services.schemas.device import AvailableDeviceSchema
 from domain.services.schemas.pipeline import PipelineConfig
 from domain.services.schemas.reader import ReaderConfig
 from domain.services.schemas.writer import WriterConfig
-from runtime.core.components.factories.model import ModelFactory
+from runtime.core.components.factories.model import DeviceResolver, ModelFactory
 from runtime.core.components.factories.reader import StreamReaderFactory
 from runtime.core.components.factories.writer import StreamWriterFactory
 from runtime.core.components.processor import Processor
@@ -39,7 +39,7 @@ class DefaultComponentFactory(ComponentFactory):
         available_devices: list[AvailableDeviceSchema] | None = None,
         dataset_resolver: DatasetResolver | None = None,
     ) -> None:
-        self._model_factory = ModelFactory(available_devices=available_devices)
+        self._model_factory = ModelFactory(device_resolver=DeviceResolver(available_devices=available_devices))
         self._reader_factory = StreamReaderFactory(dataset_resolver=dataset_resolver)
 
     def create_source(self, reader_cfg: ReaderConfig | None) -> Source:

--- a/application/backend/app/runtime/core/components/broadcaster.py
+++ b/application/backend/app/runtime/core/components/broadcaster.py
@@ -84,7 +84,7 @@ class FrameBroadcaster[T]:
                 try:
                     queue.put_nowait(self._slot.latest)
                 except Full:
-                    logging.warning("Could not send latest frame to new consumer - queue full")
+                    logging.debug("Could not send latest frame to new consumer - queue full")
 
             logging.info(
                 "%s: registered consumer '%s'. Total consumers: %d", self.name, consumer_name, len(self._consumers)
@@ -113,8 +113,6 @@ class FrameBroadcaster[T]:
                     self._handle_full_queue(consumer_name, queue, frame)
                 except Exception:
                     logger.exception("Error broadcasting to queue")
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug("%s/%s depth: %d/%d", self.name, consumer_name, queue.qsize(), queue.maxsize)
 
     def clear(self) -> None:
         """
@@ -134,9 +132,6 @@ class FrameBroadcaster[T]:
 
     def _handle_full_queue(self, consumer_name: str, queue: Queue[T], frame: T) -> None:
         """Handle a full queue by dropping the oldest frame and adding the new one."""
-        logger.debug(
-            "%s/%s full (%d/%d), dropping oldest frame", self.name, consumer_name, queue.qsize(), queue.maxsize
-        )
         try:
             queue.get_nowait()
         except Empty:
@@ -145,6 +140,6 @@ class FrameBroadcaster[T]:
         try:
             queue.put_nowait(frame)
         except Full:
-            logger.warning("Queue still full after clearing, skipping frame")
+            logger.debug("Queue still full after clearing, skipping frame")
         except Exception:
             logger.exception("Error replacing frame in full queue")

--- a/application/backend/app/runtime/core/components/broadcaster.py
+++ b/application/backend/app/runtime/core/components/broadcaster.py
@@ -110,7 +110,7 @@ class FrameBroadcaster[T]:
                 try:
                     queue.put_nowait(frame)
                 except Full:
-                    self._handle_full_queue(queue, frame)
+                    self._handle_full_queue(consumer_name, queue, frame)
                 except Exception:
                     logger.exception("Error broadcasting to queue")
 
@@ -130,7 +130,7 @@ class FrameBroadcaster[T]:
                         break
             self._slot.clear()
 
-    def _handle_full_queue(self, queue: Queue[T], frame: T) -> None:
+    def _handle_full_queue(self, consumer_name: str, queue: Queue[T], frame: T) -> None:
         """Handle a full queue by dropping the oldest frame and adding the new one."""
         try:
             queue.get_nowait()
@@ -140,6 +140,6 @@ class FrameBroadcaster[T]:
         try:
             queue.put_nowait(frame)
         except Full:
-            logger.debug("Queue still full after clearing, skipping frame")
+            logger.debug("Queue still full after clearing for consumer '%s', skipping frame", consumer_name)
         except Exception:
-            logger.exception("Error replacing frame in full queue")
+            logger.exception("Error replacing frame in full queue for consumer '%s'", consumer_name)

--- a/application/backend/app/runtime/core/components/broadcaster.py
+++ b/application/backend/app/runtime/core/components/broadcaster.py
@@ -110,7 +110,7 @@ class FrameBroadcaster[T]:
                 try:
                     queue.put_nowait(frame)
                 except Full:
-                    self._handle_full_queue(consumer_name, queue, frame)
+                    self._handle_full_queue(queue, frame)
                 except Exception:
                     logger.exception("Error broadcasting to queue")
 
@@ -130,7 +130,7 @@ class FrameBroadcaster[T]:
                         break
             self._slot.clear()
 
-    def _handle_full_queue(self, consumer_name: str, queue: Queue[T], frame: T) -> None:
+    def _handle_full_queue(self, queue: Queue[T], frame: T) -> None:
         """Handle a full queue by dropping the oldest frame and adding the new one."""
         try:
             queue.get_nowait()

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -1,6 +1,8 @@
 #  Copyright (C) 2025 Intel Corporation
 #  SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from instantlearn.data.base.batch import Batch
 from instantlearn.models.matcher import Matcher
 from instantlearn.models.per_dino import PerDino
@@ -15,6 +17,8 @@ from runtime.core.components.models.passthrough_model import PassThroughModelHan
 from runtime.core.components.models.torch_model import TorchModelHandler
 from runtime.services.device import list_available_devices
 from settings import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 class DeviceResolver:
@@ -55,18 +59,25 @@ class ModelFactory:
         config: ModelConfig | None,
         configured_device: Device | None = None,
     ) -> ModelHandler:
+        logger.info("Initializing a model: %s", config)
+
         if reference_batch is None:
+            logger.info("No prompts provided, creating a passthrough model")
             return PassThroughModelHandler()
         settings = get_settings()
         if not settings.processor_inference_enabled:
+            logger.info("Inference is disabled in the application settings, creating a passthrough model")
             return PassThroughModelHandler()
         if config is None:
+            logger.info("No model config is provided, creating a passthrough model")
             return PassThroughModelHandler()
 
         selected_device = self._device_resolver.resolve_device(configured_device)
+        logger.info("Accelerator selected: %s", selected_device)
 
         match config:
             case MatcherConfig() as config:
+                logger.info("Initializing a Matcher instance")
                 # if the model is converted to the OV format, the precision should be strictly fp32
                 # as a suggestion we can handle conversion at the higher level factory,
                 # as it knows if the model should be converted or not and can override the configuration
@@ -85,14 +96,17 @@ class ModelFactory:
                     device=selected_device,
                 )
                 if settings.processor_openvino_enabled:
+                    logger.info("Using the OpenVINO backend for Matcher")
                     return OpenVINOModelHandler(
                         model=model,
                         reference_batch=reference_batch,
                         precision=precision,
                         compression_preset=config.preset,
                     )
+                logger.info("Using the Torch backend for Matcher")
                 return TorchModelHandler(model, reference_batch)
             case PerDinoConfig() as config:
+                logger.info("Initializing a PerDINO instance")
                 model = PerDino(
                     sam=config.sam_model,
                     encoder_model=config.encoder_model,
@@ -104,8 +118,10 @@ class ModelFactory:
                     precision=config.precision,
                     device=selected_device,
                 )
+                logger.info("Using the Torch backend for PerDINO")
                 return TorchModelHandler(model, reference_batch)
             case SoftMatcherConfig() as config:
+                logger.info("Initializing a SoftMatcher instance")
                 model = SoftMatcher(
                     sam=config.sam_model,
                     encoder_model=config.encoder_model,
@@ -120,8 +136,10 @@ class ModelFactory:
                     precision=config.precision,
                     device=selected_device,
                 )
+                logger.info("Using the Torch backend for SoftMatcher")
                 return TorchModelHandler(model, reference_batch)
             case Sam3Config() as config:
+                logger.info("Initializing a SAM3 instance")
                 has_bboxes = any(s.bboxes is not None for s in reference_batch.samples)
                 prompt_mode = Sam3PromptMode.CANVAS if has_bboxes else Sam3PromptMode.CLASSIC
                 model = SAM3(
@@ -131,6 +149,8 @@ class ModelFactory:
                     device=selected_device,
                     prompt_mode=prompt_mode,
                 )
+                logger.info("Using the Torch backend for SAM3")
                 return TorchModelHandler(model, reference_batch)
             case _:
+                logger.info("Model config didn't match any known type, falling back to a pass through model")
                 return PassThroughModelHandler()

--- a/application/backend/app/runtime/core/components/factories/model.py
+++ b/application/backend/app/runtime/core/components/factories/model.py
@@ -48,10 +48,9 @@ class DeviceResolver:
 class ModelFactory:
     def __init__(
         self,
-        device_resolver: DeviceResolver | None = None,
-        available_devices: list[AvailableDeviceSchema] | None = None,
+        device_resolver: DeviceResolver,
     ) -> None:
-        self._device_resolver = device_resolver or DeviceResolver(available_devices=available_devices)
+        self._device_resolver = device_resolver
 
     def create(  # noqa: PLR0911
         self,

--- a/application/backend/app/runtime/core/components/models/openvino_model.py
+++ b/application/backend/app/runtime/core/components/models/openvino_model.py
@@ -59,6 +59,8 @@ class OpenVINOModelHandler(ModelHandler):
         # Export on CPU to avoid XPU/CUDA compilation issues during tracing.
         # The exported OpenVINO model can then be run on any device (CPU, GPU, etc.)
         original_device = next(self._model.parameters()).device
+        logger.info("Original device %s", original_device)
+
         self._model.cpu()
         try:
             with tempfile.TemporaryDirectory() as tmp_dir:

--- a/application/backend/app/runtime/core/components/models/torch_model.py
+++ b/application/backend/app/runtime/core/components/models/torch_model.py
@@ -30,7 +30,6 @@ class TorchModelHandler(ModelHandler):
         self._model.fit(self._reference_batch)
 
     def predict(self, inputs: list[InputData]) -> list[dict[str, np.ndarray]]:
-        logger.debug("Inference started: model=%s batch size=%d", type(self._model).__name__, len(inputs))
         batch = self._build_batch(inputs)
         torch_results = self._model.predict(batch)
         results = []

--- a/application/backend/app/runtime/core/components/processor.py
+++ b/application/backend/app/runtime/core/components/processor.py
@@ -159,7 +159,6 @@ class Processor(PipelineComponent):
             is_manual = input_data.context.get("requires_manual_control", False)
 
             if not is_manual and self._skip_policy.should_skip():
-                logger.debug("Frame skipped (timestamp=%s)", input_data.timestamp)
                 continue
 
             batch_data.append(input_data)

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     processor_frame_skip_interval: int = Field(default=3, ge=0, alias="PROCESSOR_FRAME_SKIP_INTERVAL")
     processor_frame_skip_amount: int = Field(default=2, ge=0, alias="PROCESSOR_FRAME_SKIP_AMOUNT")
     processor_inference_enabled: bool = Field(default=True, alias="PROCESSOR_INFERENCE_ENABLED")
-    processor_openvino_enabled: bool = Field(default=False, alias="PROCESSOR_OPENVINO_ENABLED")
+    processor_openvino_enabled: bool = Field(default=True, alias="PROCESSOR_OPENVINO_ENABLED")
 
     # WebRTC
     webrtc_advertise_ip: str | None = Field(default=None, alias="WEBRTC_ADVERTISE_IP")

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -134,7 +134,7 @@ class Settings(BaseSettings):
     # Processor configuration
     processor_batch_size: int = Field(default=1, alias="PROCESSOR_BATCH_SIZE")
     processor_frame_skip_interval: int = Field(default=3, ge=0, alias="PROCESSOR_FRAME_SKIP_INTERVAL")
-    processor_frame_skip_amount: int = Field(default=1, ge=0, alias="PROCESSOR_FRAME_SKIP_AMOUNT")
+    processor_frame_skip_amount: int = Field(default=2, ge=0, alias="PROCESSOR_FRAME_SKIP_AMOUNT")
     processor_inference_enabled: bool = Field(default=True, alias="PROCESSOR_INFERENCE_ENABLED")
     processor_openvino_enabled: bool = Field(default=False, alias="PROCESSOR_OPENVINO_ENABLED")
 

--- a/application/backend/tests/unit/runtime/core/components/factories/test_model.py
+++ b/application/backend/tests/unit/runtime/core/components/factories/test_model.py
@@ -34,12 +34,11 @@ class TestDeviceResolver:
         ],
     )
     def test_resolve_device_auto_priority(self, available_devices, expected_device):
-        resolver = DeviceResolver()
-        with patch("runtime.core.components.factories.model.list_available_devices", return_value=available_devices):
-            assert resolver.resolve_device("auto") == expected_device
+        resolver = DeviceResolver(available_devices=available_devices)
+        assert resolver.resolve_device("auto") == expected_device
 
     def test_resolve_device_keeps_explicit_device(self):
-        resolver = DeviceResolver()
+        resolver = DeviceResolver(available_devices=[])
         assert resolver.resolve_device("cuda") == "cuda"
 
     @pytest.mark.parametrize(
@@ -58,9 +57,8 @@ class TestDeviceResolver:
         ],
     )
     def test_resolve_device_none_behaves_like_auto(self, available_devices, expected_device):
-        resolver = DeviceResolver()
-        with patch("runtime.core.components.factories.model.list_available_devices", return_value=available_devices):
-            assert resolver.resolve_device(None) == expected_device
+        resolver = DeviceResolver(available_devices=available_devices)
+        assert resolver.resolve_device(None) == expected_device
 
 
 class TestModelFactory:


### PR DESCRIPTION
## Description
- Made DeviceResolver explicit during injection instead of internally instantiated.
- Added verbose initialisation and backend logging to ModelFactory. Reduced noisy logging in broadcaster.py (downgrading warnings) and silencing aiortc debug logs.