### PR TITLE
Fix inference for images folder

### DIFF
--- a/application/backend/app/runtime/core/components/pipeline.py
+++ b/application/backend/app/runtime/core/components/pipeline.py
@@ -158,8 +158,10 @@ class Pipeline:
             new_component: The new component instance.
         """
         component_cls = new_component.__class__
-        self._inbound_broadcaster.clear()
-        self._outbound_broadcaster.clear()
+        if isinstance(new_component, Source):
+            self._inbound_broadcaster.clear()
+        if isinstance(new_component, (Source | Processor)):
+            self._outbound_broadcaster.clear()
         self._components[component_cls] = new_component
         if start:
             thread = Thread(target=new_component, daemon=False)

--- a/application/backend/app/runtime/core/components/schemas/__init__.py
+++ b/application/backend/app/runtime/core/components/schemas/__init__.py
@@ -1,2 +1,0 @@
-# Copyright (C) 2025 Intel Corporation
-# SPDX-License-Identifier: Apache-2.0

--- a/application/backend/tests/unit/runtime/core/components/test_pipeline.py
+++ b/application/backend/tests/unit/runtime/core/components/test_pipeline.py
@@ -438,7 +438,7 @@ class TestPipeline:
         mock_outbound_broadcaster,
         mock_frame_repository,
     ):
-        """Replacing the processor must not clear the inbound broadcaster slot,
+        """Replacing the processor must not clear the inbound broadcaster data,
         so that a manual-mode source (e.g. ImageFolderReader) can replay the
         last frame to the newly registered processor."""
         pipeline = Pipeline(

--- a/application/backend/tests/unit/runtime/core/components/test_pipeline.py
+++ b/application/backend/tests/unit/runtime/core/components/test_pipeline.py
@@ -430,7 +430,7 @@ class TestPipeline:
         mock_outbound_broadcaster.clear.assert_called_once()
         pipeline.stop()
 
-    def test_set_processor_clears_inbound_and_outbound_broadcasters(
+    def test_set_processor_clears_only_outbound_broadcaster(
         self,
         project_id,
         mock_processor,
@@ -438,6 +438,9 @@ class TestPipeline:
         mock_outbound_broadcaster,
         mock_frame_repository,
     ):
+        """Replacing the processor must not clear the inbound broadcaster slot,
+        so that a manual-mode source (e.g. ImageFolderReader) can replay the
+        last frame to the newly registered processor."""
         pipeline = Pipeline(
             project_id=project_id,
             frame_repository=mock_frame_repository,
@@ -447,11 +450,11 @@ class TestPipeline:
 
         pipeline.set_processor(mock_processor)
 
-        mock_inbound_broadcaster.clear.assert_called_once()
+        mock_inbound_broadcaster.clear.assert_not_called()
         mock_outbound_broadcaster.clear.assert_called_once()
         pipeline.stop()
 
-    def test_set_sink_clears_inbound_and_outbound_broadcasters(
+    def test_set_sink_does_not_clear_any_broadcaster(
         self,
         project_id,
         mock_sink,
@@ -459,6 +462,8 @@ class TestPipeline:
         mock_outbound_broadcaster,
         mock_frame_repository,
     ):
+        """Replacing the sink must not clear either broadcaster — it has no bearing
+        on frame flow between source and processor."""
         pipeline = Pipeline(
             project_id=project_id,
             frame_repository=mock_frame_repository,
@@ -468,6 +473,6 @@ class TestPipeline:
 
         pipeline.set_sink(mock_sink)
 
-        mock_inbound_broadcaster.clear.assert_called_once()
-        mock_outbound_broadcaster.clear.assert_called_once()
+        mock_inbound_broadcaster.clear.assert_not_called()
+        mock_outbound_broadcaster.clear.assert_not_called()
         pipeline.stop()


### PR DESCRIPTION
This PR fixes the issue with images folder: WebRTC stream was not being refreshed with the new inference output on model update/switch. 
Replacing the processor/sink must not clear the inbound broadcaster latest frame slot, so that a manual-mode source (e.g. ImageFolderReader) can replay the last frame to the newly registered processor.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

Closes #994, #1009
