### PR TITLE
fix: Fix the order of used ref nodes

### DIFF
--- a/application/ui/src/features/stream/images-folder-stream/api/use-frames.hook.ts
+++ b/application/ui/src/features/stream/images-folder-stream/api/use-frames.hook.ts
@@ -51,6 +51,7 @@ const useFramesQuery = (sourceId: string, activeFrameIdx: number) => {
 
                 return previousPage;
             },
+            staleTime: 1000 * 60,
         }
     );
 };

--- a/application/ui/src/features/stream/images-folder-stream/frames-list/frame-thumbnail.component.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/frames-list/frame-thumbnail.component.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { RefObject, useCallback, useLayoutEffect, useRef } from 'react';
+import { RefObject, useLayoutEffect, useRef } from 'react';
 
 import { DOMRefValue, Loading, View } from '@geti/ui';
+import { useUnwrapDOMRef } from '@react-spectrum/utils';
 import { clsx } from 'clsx';
 
 import { type FrameType } from '../api/interface';
@@ -20,51 +21,44 @@ interface FrameThumbnailProps {
 }
 
 const useObserveThumbnail = (rootRef: RefObject<HTMLDivElement | null>, onIntersect: (() => void) | undefined) => {
+    const ref = useRef<DOMRefValue<HTMLDivElement> | null>(null);
+    const unwrappedRef = useUnwrapDOMRef(ref);
     const handleIntersectionRef = useRef(onIntersect);
 
     useLayoutEffect(() => {
         handleIntersectionRef.current = onIntersect;
     }, [onIntersect]);
 
-    const handleRef = useCallback(
-        (domRefValue: DOMRefValue<HTMLElement> | null) => {
-            const ref = domRefValue?.UNSAFE_getDOMNode();
+    useLayoutEffect(() => {
+        if (unwrappedRef.current == null || rootRef.current === null) {
+            return;
+        }
 
-            if (ref == null || rootRef.current === null) {
-                return;
-            }
-
-            if (handleIntersectionRef.current === undefined) {
-                return;
-            }
-
-            const observer = new IntersectionObserver(
-                (entries) => {
-                    if (entries.length === 0) {
-                        return;
-                    }
-
-                    if (entries[0].isIntersecting) {
-                        handleIntersectionRef.current?.();
-                    }
-                },
-                {
-                    threshold: 0.01,
-                    rootMargin: '200px',
-                    root: rootRef.current,
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.length === 0) {
+                    return;
                 }
-            );
 
-            observer.observe(ref);
+                if (entries[0].isIntersecting) {
+                    handleIntersectionRef.current?.();
+                }
+            },
+            {
+                threshold: 0.01,
+                rootMargin: '200px',
+                root: rootRef.current,
+            }
+        );
 
-            return () => {
-                observer.disconnect();
-            };
-        },
-        [rootRef]
-    );
+        observer.observe(unwrappedRef.current);
 
-    return handleRef;
+        return () => {
+            observer.disconnect();
+        };
+    }, [unwrappedRef, rootRef]);
+
+    return ref;
 };
 
 const FrameThumbnailPlaceholder = () => {

--- a/application/ui/src/features/stream/images-folder-stream/frames-list/frame-thumbnail.component.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/frames-list/frame-thumbnail.component.tsx
@@ -5,8 +5,7 @@
 
 import { RefObject, useLayoutEffect, useRef } from 'react';
 
-import { DOMRefValue, Loading, View } from '@geti/ui';
-import { useUnwrapDOMRef } from '@react-spectrum/utils';
+import { DOMRefValue, Loading, useUnwrapDOMRef, View } from '@geti/ui';
 import { clsx } from 'clsx';
 
 import { type FrameType } from '../api/interface';

--- a/application/ui/src/features/stream/images-folder-stream/frames-list/frames-list.component.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/frames-list/frames-list.component.tsx
@@ -60,7 +60,7 @@ const useScrollToActiveFrame = (ref: RefObject<HTMLDivElement | null>, activeFra
     }, [ref, activeFrameIndex]);
 };
 
-const OFFSET_TO_FETCH_NEW_PAGE = 4;
+const OFFSET_TO_FETCH_NEW_PAGE = 8;
 
 export const FramesList = ({
     activeFrameIndex,


### PR DESCRIPTION
# Pull Request

## Description

<!-- What does this PR do? Why is it needed? -->

The issue was with the order and race condition of mounted refs in react. Refs are mounted from the bottom to up, i.e. children -> parent. It could have happened that in the child we did `parentRef(rootRef).current !== null` which would be almost always `false` and based on that almost never create the observer. 
This PR fixes that.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

Fix #1031 

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
