### PR TITLE
more image folder fixes

### DIFF
--- a/application/backend/app/api/endpoints/sources.py
+++ b/application/backend/app/api/endpoints/sources.py
@@ -115,10 +115,41 @@ def delete_source(project_id: UUID, source_id: UUID, source_service: SourceServi
     responses={
         status.HTTP_200_OK: {"description": "Successfully retrieved the list of frames for the project's source."},
         status.HTTP_400_BAD_REQUEST: {
-            "description": "Source does not support frame navigation or source is not active."
+            "description": "Source does not support frame navigation or source is not active.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
         },
-        status.HTTP_404_NOT_FOUND: {"description": "Project or source not found."},
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Unexpected error occurred."},
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Project or source not found.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
+        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "description": "Unexpected error occurred.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
+        },
     },
 )
 def get_frames(
@@ -148,10 +179,41 @@ def get_frames(
     responses={
         status.HTTP_200_OK: {"description": "Successfully retrieved the current frame index."},
         status.HTTP_400_BAD_REQUEST: {
-            "description": "Source does not support frame navigation or source is not active."
+            "description": "Source does not support frame navigation or source is not active.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
         },
-        status.HTTP_404_NOT_FOUND: {"description": "Project or source not found."},
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Unexpected error occurred."},
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Project or source not found.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
+        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "description": "Unexpected error occurred.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
+        },
     },
 )
 def get_frame_index(
@@ -177,10 +239,41 @@ def get_frame_index(
     responses={
         status.HTTP_200_OK: {"description": "Successfully seeked to the specified frame."},
         status.HTTP_400_BAD_REQUEST: {
-            "description": "Invalid frame index, source does not support seeking, or source is not active."
+            "description": "Invalid frame index, source does not support seeking, or source is not active.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
         },
-        status.HTTP_404_NOT_FOUND: {"description": "Project or source not found."},
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Unexpected error occurred."},
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Project or source not found.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
+        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "description": "Unexpected error occurred.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                        "required": ["detail"],
+                    }
+                }
+            },
+        },
     },
 )
 def seek_frame(

--- a/application/backend/app/runtime/core/components/readers/image_folder_reader.py
+++ b/application/backend/app/runtime/core/components/readers/image_folder_reader.py
@@ -154,10 +154,8 @@ class ImageFolderReader(StreamReader):
                 raise IndexError(f"Index {index} out of range [0, {len(self._image_paths)})")
 
             self._current_index = index
-            current_image = self._read_image_at_current_index()
-            if current_image is None:
-                self._last_image = None
-                self._last_image_path = None
+            self._last_image = None
+            self._last_image_path = None
 
     def __len__(self) -> int:
         """Return the total number of images in the folder."""
@@ -199,6 +197,9 @@ class ImageFolderReader(StreamReader):
 
         frames: list[FrameMetadata] = []
         for idx, image_path in enumerate(image_paths, start=offset):
+            if not image_path.exists():
+                raise ValueError(f"Image file no longer accessible: {image_path}")
+
             thumbnail: str | None
             if idx in self._thumbnail_cache:
                 thumbnail = self._thumbnail_cache[idx]

--- a/application/backend/tests/unit/runtime/core/components/readers/test_image_folder_reader.py
+++ b/application/backend/tests/unit/runtime/core/components/readers/test_image_folder_reader.py
@@ -437,17 +437,24 @@ class TestImageFolderReaderMissingFiles:
         with pytest.raises(ValueError, match="Image file no longer accessible"):
             reader.read()
 
-    def test_seek_raises_when_target_file_is_deleted(self, reader, temp_image_folder):
+    def test_read_raises_after_seek_when_target_file_is_deleted(self, reader, temp_image_folder):
         reader.connect()
         reader._image_paths[2].unlink()
+        reader.seek(2)
         with pytest.raises(ValueError, match="Image file no longer accessible"):
-            reader.seek(2)
+            reader.read()
 
     def test_list_frames_raises_when_folder_is_deleted(self, reader, temp_image_folder):
         reader.connect()
         shutil.rmtree(str(temp_image_folder))
         with pytest.raises(ValueError, match="Images folder no longer accessible"):
             reader.list_frames()
+
+    def test_list_frames_raises_when_cached_file_is_deleted(self, reader):
+        reader.connect()
+        reader._image_paths[0].unlink()
+        with pytest.raises(ValueError, match="Image file no longer accessible"):
+            reader.list_frames(offset=0, limit=1)
 
     def test_list_frames_raises_immediately_when_folder_never_existed(self):
         """On restart with a missing directory, list_frames should fail fast without waiting."""

--- a/application/backend/tests/unit/runtime/core/components/test_source.py
+++ b/application/backend/tests/unit/runtime/core/components/test_source.py
@@ -1,3 +1,4 @@
+from threading import Event, Thread
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -156,6 +157,43 @@ class TestSource:
         self.source.run()
 
         broadcast_calls = [call.args[0] for call in self.mock_broadcaster.broadcast.call_args_list]
+        error_data = next(c for c in broadcast_calls if isinstance(c, ErrorData))
+        assert "Image file no longer accessible" in error_data.message
+
+    def test_source_broadcasts_read_error_after_seek_in_manual_mode(self):
+        """Test that a manual seek triggers the next read, which broadcasts read errors."""
+        self.mock_stream_reader.requires_manual_control = True
+        source = Source(self.mock_stream_reader)
+        source.setup(self.mock_broadcaster)
+
+        first_read_called = Event()
+        first_frame = make_input("frame1")
+
+        def read_side_effect(*args, **kwargs):
+            if not first_read_called.is_set():
+                first_read_called.set()
+                return first_frame
+
+            source.stop()
+            raise ValueError("Image file no longer accessible")
+
+        self.mock_stream_reader.read.side_effect = read_side_effect
+
+        thread = Thread(target=source.run, daemon=True)
+        thread.start()
+
+        assert first_read_called.wait(timeout=2)
+
+        source.seek(3)
+
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+        self.mock_stream_reader.seek.assert_called_once_with(3)
+
+        broadcast_calls = [call.args[0] for call in self.mock_broadcaster.broadcast.call_args_list]
+        assert any(call is first_frame for call in broadcast_calls)
+
         error_data = next(c for c in broadcast_calls if isinstance(c, ErrorData))
         assert "Image file no longer accessible" in error_data.message
 

--- a/application/ui/src/features/stream/images-folder-stream/api/use-activate-frame.hook.ts
+++ b/application/ui/src/features/stream/images-folder-stream/api/use-activate-frame.hook.ts
@@ -40,20 +40,36 @@ export const useActivateFrame = () => {
             },
             {
                 onSuccess: async () => {
-                    await queryClient.invalidateQueries({
-                        queryKey: getQueryKey([
-                            'get',
-                            '/api/v1/projects/{project_id}/sources/{source_id}/frames/index',
-                            {
-                                params: {
-                                    path: {
-                                        project_id: projectId,
-                                        source_id: sourceId,
+                    await Promise.all([
+                        queryClient.invalidateQueries({
+                            queryKey: getQueryKey([
+                                'get',
+                                '/api/v1/projects/{project_id}/sources/{source_id}/frames/index',
+                                {
+                                    params: {
+                                        path: {
+                                            project_id: projectId,
+                                            source_id: sourceId,
+                                        },
                                     },
                                 },
-                            },
-                        ]),
-                    });
+                            ]),
+                        }),
+                        queryClient.invalidateQueries({
+                            queryKey: getQueryKey([
+                                'get',
+                                '/api/v1/projects/{project_id}/sources/{source_id}/frames',
+                                {
+                                    params: {
+                                        path: {
+                                            project_id: projectId,
+                                            source_id: sourceId,
+                                        },
+                                    },
+                                },
+                            ]),
+                        }),
+                    ]);
                     onSuccess();
                 },
             }

--- a/application/ui/src/features/stream/images-folder-stream/api/use-frames.hook.ts
+++ b/application/ui/src/features/stream/images-folder-stream/api/use-frames.hook.ts
@@ -32,6 +32,11 @@ const useFramesQuery = (sourceId: string, activeFrameIdx: number) => {
             },
         },
         {
+            meta: {
+                error: {
+                    notify: true,
+                },
+            },
             pageParamName: 'offset',
             initialPageParam: queryOffset,
             getNextPageParam: ({ pagination }: FramesResponseType) => {
@@ -59,6 +64,7 @@ const useFramesQuery = (sourceId: string, activeFrameIdx: number) => {
 export const useGetFrames = (sourceId: string, activeFrameIdx: number) => {
     const {
         data,
+        error,
         hasNextPage,
         isFetchingNextPage,
         isPending,
@@ -90,6 +96,7 @@ export const useGetFrames = (sourceId: string, activeFrameIdx: number) => {
         isFetchingNextFrames: isFetchingNextPage,
         fetchPreviousPage: handleFetchPreviousPage,
         isPending,
+        hasError: error !== null,
         framesCount,
     } as const;
 };

--- a/application/ui/src/features/stream/images-folder-stream/images-folder-stream.component.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/images-folder-stream.component.tsx
@@ -106,7 +106,10 @@ export const ImagesFolderStream = ({ sourceId }: ImagesFolderStreamProps) => {
     // const [promptMode] = usePromptMode();
     const { data: activeFrame } = useGetActiveFrame(sourceId);
     const activeFrameIdx = activeFrame.index;
-    const { frames, fetchNextPage, fetchPreviousPage, framesCount, isPending } = useGetFrames(sourceId, activeFrameIdx);
+    const { frames, fetchNextPage, fetchPreviousPage, framesCount, isPending, hasError } = useGetFrames(
+        sourceId,
+        activeFrameIdx
+    );
     const { activateFrame, nextFrame, prevFrame, framesRef } = useActiveFrameSelection({
         sourceId,
         frames,
@@ -165,7 +168,7 @@ export const ImagesFolderStream = ({ sourceId }: ImagesFolderStreamProps) => {
                 <CaptureFrameButton />
             </View>
             <View gridArea={'frames'} backgroundColor={'gray-100'}>
-                {isPending ? (
+                {hasError ? null : isPending ? (
                     <Loading mode={'inline'} size={'M'} style={{ height: '100%', width: '100%' }} />
                 ) : (
                     <FramesList

--- a/application/ui/src/features/stream/images-folder-stream/images-folder-stream.component.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/images-folder-stream.component.tsx
@@ -23,10 +23,12 @@ const useActiveFrameSelection = ({
     sourceId,
     activeFrameIdx,
     frames,
+    canNavigate,
 }: {
     sourceId: string;
     activeFrameIdx: number;
     frames: FrameAPIType[];
+    canNavigate: boolean;
 }) => {
     const activateFrameMutation = useActivateFrame();
     const framesRef = useRef<HTMLDivElement>(null);
@@ -71,6 +73,10 @@ const useActiveFrameSelection = ({
     };
 
     const nextFrame = () => {
+        if (!canNavigate) {
+            return;
+        }
+
         const nextFrameIdx = activeFrameIdx + 1;
 
         if (nextFrameIdx >= framesCount) {
@@ -81,6 +87,10 @@ const useActiveFrameSelection = ({
     };
 
     const prevFrame = () => {
+        if (!canNavigate) {
+            return;
+        }
+
         const prevFrameIdx = activeFrameIdx - 1;
 
         if (prevFrameIdx < 0) {
@@ -110,14 +120,17 @@ export const ImagesFolderStream = ({ sourceId }: ImagesFolderStreamProps) => {
         sourceId,
         activeFrameIdx
     );
+    const canNavigateFrames = !hasError && !isPending && framesCount > 0;
+
     const { activateFrame, nextFrame, prevFrame, framesRef } = useActiveFrameSelection({
         sourceId,
         frames,
         activeFrameIdx,
+        canNavigate: canNavigateFrames,
     });
 
-    const isPrevFrameButtonDisabled = activeFrameIdx === 0;
-    const isNextFrameButtonDisabled = activeFrameIdx === framesCount - 1;
+    const isPrevFrameButtonDisabled = !canNavigateFrames || activeFrameIdx === 0;
+    const isNextFrameButtonDisabled = !canNavigateFrames || activeFrameIdx === framesCount - 1;
 
     return (
         <Grid

--- a/application/ui/src/features/stream/images-folder-stream/images-folder.stream.component.test.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/images-folder.stream.component.test.tsx
@@ -227,4 +227,73 @@ describe('ImagesFolderStream', () => {
             expect(seekCalls).toBe(0);
         });
     });
+
+    it('clears stale frames after a later navigation refetch fails', async () => {
+        let activeIndex = 5;
+        let seekCalls = 0;
+        let framesShouldFail = false;
+
+        server.use(
+            http.get('/api/v1/projects/{project_id}/sources/{source_id}/frames', () => {
+                if (framesShouldFail) {
+                    return HttpResponse.json(
+                        {
+                            detail: 'Images folder no longer accessible: /deleted/dataset',
+                        },
+                        { status: 400 }
+                    );
+                }
+
+                const frames = Array.from({ length: 18 }).map((_, index) =>
+                    getMockedFrame({
+                        index,
+                        thumbnail: `base64;frame-${index}`,
+                    })
+                );
+
+                return HttpResponse.json({
+                    frames,
+                    pagination: {
+                        count: 18,
+                        total: 18,
+                        offset: 0,
+                        limit: 20,
+                    },
+                });
+            }),
+            http.get('/api/v1/projects/{project_id}/sources/{source_id}/frames/index', () => {
+                return HttpResponse.json({
+                    index: activeIndex,
+                });
+            }),
+            http.post('/api/v1/projects/{project_id}/sources/{source_id}/frames/{index}', ({ params }) => {
+                seekCalls += 1;
+                activeIndex = Number(params.index);
+
+                return HttpResponse.json({
+                    index: activeIndex,
+                });
+            })
+        );
+
+        await renderImagesFolderStream();
+
+        expect(await screen.findByRole('option', { name: 'Frame #5' })).toHaveAttribute('data-isselected', 'true');
+
+        framesShouldFail = true;
+
+        fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+        expect(await screen.findByText('Images folder no longer accessible: /deleted/dataset')).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Frame #0' })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Previous Frame' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Next Frame' })).toBeDisabled();
+
+        fireEvent.keyDown(document, { key: 'ArrowLeft' });
+        fireEvent.click(screen.getByRole('button', { name: 'Next Frame' }));
+
+        await waitFor(() => {
+            expect(seekCalls).toBe(1);
+        });
+    });
 });

--- a/application/ui/src/features/stream/images-folder-stream/images-folder.stream.component.test.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/images-folder.stream.component.test.tsx
@@ -5,7 +5,7 @@
 
 import { FrameAPIType } from '@/api';
 import { render } from '@/test-utils';
-import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 import { SelectedFrameProvider } from 'src/shared/selected-frame-provider.component';
 import { beforeEach } from 'vitest';
@@ -173,6 +173,8 @@ describe('ImagesFolderStream', () => {
     });
 
     it('shows frames endpoint error message when frames list request fails', async () => {
+        let seekCalls = 0;
+
         server.use(
             http.get('/api/v1/projects/{project_id}/sources/{source_id}/frames', () => {
                 return HttpResponse.json(
@@ -181,6 +183,18 @@ describe('ImagesFolderStream', () => {
                     },
                     { status: 400 }
                 );
+            }),
+            http.get('/api/v1/projects/{project_id}/sources/{source_id}/frames/index', () => {
+                return HttpResponse.json({
+                    index: 5,
+                });
+            }),
+            http.post('/api/v1/projects/{project_id}/sources/{source_id}/frames/{index}', () => {
+                seekCalls += 1;
+
+                return HttpResponse.json({
+                    index: 4,
+                });
             })
         );
 
@@ -202,5 +216,15 @@ describe('ImagesFolderStream', () => {
 
         expect(await screen.findByText('Images folder no longer accessible: /deleted/dataset')).toBeInTheDocument();
         expect(screen.queryByRole('option', { name: 'Frame #0' })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Previous Frame' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Next Frame' })).toBeDisabled();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Previous Frame' }));
+        fireEvent.keyDown(document, { key: 'ArrowLeft' });
+        fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+        await waitFor(() => {
+            expect(seekCalls).toBe(0);
+        });
     });
 });

--- a/application/ui/src/features/stream/images-folder-stream/images-folder.stream.component.test.tsx
+++ b/application/ui/src/features/stream/images-folder-stream/images-folder.stream.component.test.tsx
@@ -171,4 +171,36 @@ describe('ImagesFolderStream', () => {
 
         expect(await screen.findByRole('option', { name: 'Frame #17' })).toHaveAttribute('data-isselected', 'true');
     });
+
+    it('shows frames endpoint error message when frames list request fails', async () => {
+        server.use(
+            http.get('/api/v1/projects/{project_id}/sources/{source_id}/frames', () => {
+                return HttpResponse.json(
+                    {
+                        detail: 'Images folder no longer accessible: /deleted/dataset',
+                    },
+                    { status: 400 }
+                );
+            })
+        );
+
+        render(
+            <SelectedFrameProvider>
+                <FullScreenModeProvider>
+                    <WebRTCConnectionProvider>
+                        <ImagesFolderStream sourceId={'1234'} />
+                    </WebRTCConnectionProvider>
+                </FullScreenModeProvider>
+            </SelectedFrameProvider>,
+            {
+                route: '/projects/1?mode=visual',
+                path: paths.project.pattern,
+            }
+        );
+
+        await waitForElementToBeRemoved(screen.getByRole('progressbar'));
+
+        expect(await screen.findByText('Images folder no longer accessible: /deleted/dataset')).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Frame #0' })).not.toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
# Pull Request

## Description

This PR improves handling of “image folder/source no longer accessible” scenarios across backend reader/runtime logic and the frontend frames UI by ensuring errors are surfaced and frames navigation is suppressed when the frames list cannot be retrieved.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
