### PR TITLE
fix(windows): No empty rows in camera selection on windows

### DIFF
--- a/application/backend/app/domain/services/schemas/reader.py
+++ b/application/backend/app/domain/services/schemas/reader.py
@@ -17,7 +17,7 @@ class SourceType(StrEnum):
     SAMPLE_DATASET = "sample_dataset"
 
 
-class UsbCameraConfig(BaseModel):
+class UsbCameraConfig(BaseModel, frozen=True):
     source_type: Literal[SourceType.USB_CAMERA]
     name: str | None = None
     device_id: int

--- a/application/backend/app/domain/services/schemas/reader.py
+++ b/application/backend/app/domain/services/schemas/reader.py
@@ -17,7 +17,7 @@ class SourceType(StrEnum):
     SAMPLE_DATASET = "sample_dataset"
 
 
-class UsbCameraConfig(BaseModel, frozen=True):
+class UsbCameraConfig(BaseModel):
     source_type: Literal[SourceType.USB_CAMERA]
     name: str | None = None
     device_id: int

--- a/application/backend/app/runtime/core/components/readers/usb_camera_reader.py
+++ b/application/backend/app/runtime/core/components/readers/usb_camera_reader.py
@@ -39,6 +39,7 @@ class UsbCameraReader(BaseOpenCVReader):
             backends = [cv2.CAP_V4L2]
 
         devices: list[UsbCameraConfig] = []
+        seen_devices: set[UsbCameraConfig] = set()
         camera_list = []
 
         for backend in backends:
@@ -47,12 +48,13 @@ class UsbCameraReader(BaseOpenCVReader):
         camera_list.sort(key=lambda cam: cam.index)
 
         for camera_info in camera_list:
-            devices.append(
-                UsbCameraConfig(
-                    source_type=SourceType.USB_CAMERA,
-                    device_id=camera_info.index,
-                    name=camera_info.name,
-                )
+            device = UsbCameraConfig(
+                source_type=SourceType.USB_CAMERA,
+                device_id=camera_info.index,
+                name=camera_info.name,
             )
+            if device not in seen_devices:
+                devices.append(device)
+                seen_devices.add(device)
         logger.info(f"Found {cls.__name__} input device: {devices}")
         return devices

--- a/application/backend/app/runtime/core/components/readers/usb_camera_reader.py
+++ b/application/backend/app/runtime/core/components/readers/usb_camera_reader.py
@@ -39,7 +39,7 @@ class UsbCameraReader(BaseOpenCVReader):
             backends = [cv2.CAP_V4L2]
 
         devices: list[UsbCameraConfig] = []
-        seen_devices: set[UsbCameraConfig] = set()
+        seen_device_ids: set[int] = set()
         camera_list = []
 
         for backend in backends:
@@ -53,8 +53,8 @@ class UsbCameraReader(BaseOpenCVReader):
                 device_id=camera_info.index,
                 name=camera_info.name,
             )
-            if device not in seen_devices:
+            if camera_info.index not in seen_device_ids:
                 devices.append(device)
-                seen_devices.add(device)
+                seen_device_ids.add(camera_info.index)
         logger.info(f"Found {cls.__name__} input device: {devices}")
         return devices

--- a/application/backend/pyinstaller/setenv.py
+++ b/application/backend/pyinstaller/setenv.py
@@ -3,13 +3,19 @@
 
 import os
 import sys
+from pathlib import Path
 
 from dotenv import load_dotenv
 
-dotenv_path = os.path.join(getattr(sys, "_MEIPASS", ""), ".env")
+bundle_dir = Path(getattr(sys, "_MEIPASS", ""))
+dotenv_path = os.path.join(bundle_dir, ".env")
 print(f"Loading dotenv file {dotenv_path}")
 loaded = load_dotenv(dotenv_path)
 if loaded:
     print("Dotenv loaded")
 else:
     print("No dotenv file found")
+
+sample_dataset_dir = bundle_dir.parent / "InitialData" / "templates" / "datasets"
+if sample_dataset_dir.exists():
+    os.environ.setdefault("SAMPLE_DATASET_DIR", str(sample_dataset_dir))

--- a/application/backend/tests/unit/runtime/core/components/readers/test_webcam_reader.py
+++ b/application/backend/tests/unit/runtime/core/components/readers/test_webcam_reader.py
@@ -30,14 +30,18 @@ def test_video_path(tmp_path):
 
 
 @pytest.fixture
-def usb_camera_config(test_video_path):
+def usb_camera_config():
     return UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0)
 
 
+@pytest.fixture
+def usb_camera_file_config(test_video_path):
+    return UsbCameraConfig.model_construct(source_type=SourceType.USB_CAMERA, device_id=str(test_video_path))
+
+
 class TestUsbCameraReader:
-    def test_usb_camera_reader_connect(self, usb_camera_config, test_video_path, monkeypatch):
-        reader = UsbCameraReader(config=usb_camera_config)
-        monkeypatch.setattr(reader._config, "device_id", str(test_video_path))
+    def test_usb_camera_reader_connect(self, usb_camera_file_config):
+        reader = UsbCameraReader(config=usb_camera_file_config)
 
         reader.connect()
 
@@ -47,9 +51,8 @@ class TestUsbCameraReader:
 
         reader.close()
 
-    def test_usb_camera_reader_read_frame(self, usb_camera_config, test_video_path, monkeypatch):
-        reader = UsbCameraReader(config=usb_camera_config)
-        monkeypatch.setattr(reader._config, "device_id", str(test_video_path))
+    def test_usb_camera_reader_read_frame(self, usb_camera_file_config):
+        reader = UsbCameraReader(config=usb_camera_file_config)
 
         reader.connect()
 
@@ -63,9 +66,8 @@ class TestUsbCameraReader:
 
         reader.close()
 
-    def test_usb_camera_reader_end_of_stream(self, usb_camera_config, test_video_path, monkeypatch):
-        reader = UsbCameraReader(config=usb_camera_config)
-        monkeypatch.setattr(reader._config, "device_id", str(test_video_path))
+    def test_usb_camera_reader_end_of_stream(self, usb_camera_file_config):
+        reader = UsbCameraReader(config=usb_camera_file_config)
 
         reader.connect()
 
@@ -79,9 +81,9 @@ class TestUsbCameraReader:
 
         reader.close()
 
-    def test_usb_camera_reader_connect_invalid_source(self, usb_camera_config, monkeypatch):
-        reader = UsbCameraReader(config=usb_camera_config)
-        monkeypatch.setattr(reader._config, "device_id", "/nonexistent/video.mp4")
+    def test_usb_camera_reader_connect_invalid_source(self):
+        config = UsbCameraConfig.model_construct(source_type=SourceType.USB_CAMERA, device_id="/nonexistent/video.mp4")
+        reader = UsbCameraReader(config=config)
 
         with pytest.raises(RuntimeError, match="Could not open video source"):
             reader.connect()
@@ -123,7 +125,10 @@ class TestUsbCameraReaderDiscover:
 
             # Verify enumerate_cameras was called for each expected backend
             assert mock_enumerate.call_count == backend_count
-            assert len(result) == len(fxt_camera_info_list) * backend_count
+            assert result == [
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0, name="Integrated Camera"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=1, name="USB Webcam"),
+            ]
 
     def test_discover_windows_success(self, fxt_camera_info_list):
         with (
@@ -134,11 +139,10 @@ class TestUsbCameraReaderDiscover:
 
             result = UsbCameraReader.discover()
 
-            # Windows tries 2 backends, so cameras appear twice
-            assert len(result) >= 2
-            assert result[0].source_type == SourceType.USB_CAMERA
-            assert result[0].device_id == 0
-            assert result[0].name == "Integrated Camera"
+            assert result == [
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0, name="Integrated Camera"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=1, name="USB Webcam"),
+            ]
 
     def test_discover_macos_success(self, fxt_camera_info_list):
         with (
@@ -149,8 +153,10 @@ class TestUsbCameraReaderDiscover:
 
             result = UsbCameraReader.discover()
 
-            assert len(result) == 2
-            assert all(isinstance(cam, UsbCameraConfig) for cam in result)
+            assert result == [
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0, name="Integrated Camera"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=1, name="USB Webcam"),
+            ]
 
     def test_discover_linux_success(self, fxt_camera_info_list):
         with (
@@ -161,8 +167,10 @@ class TestUsbCameraReaderDiscover:
 
             result = UsbCameraReader.discover()
 
-            assert len(result) == 2
-            assert all(isinstance(cam, UsbCameraConfig) for cam in result)
+            assert result == [
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0, name="Integrated Camera"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=1, name="USB Webcam"),
+            ]
 
     def test_discover_no_cameras_found(self):
         with (
@@ -190,10 +198,30 @@ class TestUsbCameraReaderDiscover:
 
             result = UsbCameraReader.discover()
 
-            assert len(result) == 3
-            assert result[0].device_id == 0
-            assert result[0].name == "Camera 0"
-            assert result[1].device_id == 1
-            assert result[1].name == "Camera 1"
-            assert result[2].device_id == 2
-            assert result[2].name == "Camera 2"
+            assert result == [
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0, name="Camera 0"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=1, name="Camera 1"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=2, name="Camera 2"),
+            ]
+
+    def test_discover_returns_unique_cameras(self):
+        unsorted_cameras = [
+            SimpleNamespace(index=2, name="Camera 2", backend="test"),
+            SimpleNamespace(index=0, name="Camera 0", backend="test"),
+            SimpleNamespace(index=1, name="Camera 1", backend="test"),
+            SimpleNamespace(index=1, name="Camera 1", backend="test"),
+        ]
+
+        with (
+            patch("runtime.core.components.readers.usb_camera_reader.platform.system", return_value="Linux"),
+            patch("runtime.core.components.readers.usb_camera_reader.enumerate_cameras") as mock_enumerate,
+        ):
+            mock_enumerate.return_value = unsorted_cameras
+
+            result = UsbCameraReader.discover()
+
+            assert result == [
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0, name="Camera 0"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=1, name="Camera 1"),
+                UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=2, name="Camera 2"),
+            ]

--- a/application/backend/tests/unit/runtime/core/components/readers/test_webcam_reader.py
+++ b/application/backend/tests/unit/runtime/core/components/readers/test_webcam_reader.py
@@ -34,14 +34,10 @@ def usb_camera_config():
     return UsbCameraConfig(source_type=SourceType.USB_CAMERA, device_id=0)
 
 
-@pytest.fixture
-def usb_camera_file_config(test_video_path):
-    return UsbCameraConfig.model_construct(source_type=SourceType.USB_CAMERA, device_id=str(test_video_path))
-
-
 class TestUsbCameraReader:
-    def test_usb_camera_reader_connect(self, usb_camera_file_config):
-        reader = UsbCameraReader(config=usb_camera_file_config)
+    def test_usb_camera_reader_connect(self, usb_camera_config, test_video_path, monkeypatch):
+        reader = UsbCameraReader(config=usb_camera_config)
+        monkeypatch.setattr(reader._config, "device_id", str(test_video_path))
 
         reader.connect()
 
@@ -51,8 +47,9 @@ class TestUsbCameraReader:
 
         reader.close()
 
-    def test_usb_camera_reader_read_frame(self, usb_camera_file_config):
-        reader = UsbCameraReader(config=usb_camera_file_config)
+    def test_usb_camera_reader_read_frame(self, usb_camera_config, test_video_path, monkeypatch):
+        reader = UsbCameraReader(config=usb_camera_config)
+        monkeypatch.setattr(reader._config, "device_id", str(test_video_path))
 
         reader.connect()
 
@@ -66,8 +63,9 @@ class TestUsbCameraReader:
 
         reader.close()
 
-    def test_usb_camera_reader_end_of_stream(self, usb_camera_file_config):
-        reader = UsbCameraReader(config=usb_camera_file_config)
+    def test_usb_camera_reader_end_of_stream(self, usb_camera_config, test_video_path, monkeypatch):
+        reader = UsbCameraReader(config=usb_camera_config)
+        monkeypatch.setattr(reader._config, "device_id", str(test_video_path))
 
         reader.connect()
 
@@ -81,9 +79,9 @@ class TestUsbCameraReader:
 
         reader.close()
 
-    def test_usb_camera_reader_connect_invalid_source(self):
-        config = UsbCameraConfig.model_construct(source_type=SourceType.USB_CAMERA, device_id="/nonexistent/video.mp4")
-        reader = UsbCameraReader(config=config)
+    def test_usb_camera_reader_connect_invalid_source(self, usb_camera_config, monkeypatch):
+        reader = UsbCameraReader(config=usb_camera_config)
+        monkeypatch.setattr(reader._config, "device_id", "/nonexistent/video.mp4")
 
         with pytest.raises(RuntimeError, match="Could not open video source"):
             reader.connect()
@@ -209,7 +207,7 @@ class TestUsbCameraReaderDiscover:
             SimpleNamespace(index=2, name="Camera 2", backend="test"),
             SimpleNamespace(index=0, name="Camera 0", backend="test"),
             SimpleNamespace(index=1, name="Camera 1", backend="test"),
-            SimpleNamespace(index=1, name="Camera 1", backend="test"),
+            SimpleNamespace(index=1, name="Duplicate Camera 1", backend="test"),
         ]
 
         with (

--- a/application/backend/tests/unit/runtime/services/test_source_type.py
+++ b/application/backend/tests/unit/runtime/services/test_source_type.py
@@ -31,11 +31,7 @@ class TestSourceTypeService:
 
             mock_discover.assert_called_once()
             assert len(result) == 2
-            assert result[0].source_type == SourceType.USB_CAMERA
-            assert result[0].device_id == 0
-            assert result[0].name == "Camera 0"
-            assert result[1].device_id == 1
-            assert result[1].name == "Camera 1"
+            assert result == fxt_usb_camera_sources
 
     def test_list_available_sources_usb_camera_empty(self, service):
         with patch("runtime.core.components.readers.usb_camera_reader.UsbCameraReader.discover") as mock_discover:


### PR DESCRIPTION
# Pull Request

## Description

No empty rows in camera selection on windows and fix for sample datasets in tauri.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

Closes: https://github.com/open-edge-platform/geti-instant-learn/issues/690

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---

<!-- Optional sections below - delete if not needed -->

## Examples

<!-- Pseudo-code, usage examples, or before/after comparisons -->

## Screenshots

<!-- UI changes or visual demos -->
