### PR TITLE
feat: implement user-level control to activate-deactivate sink

### DIFF
--- a/application/backend/app/api/endpoints/sinks.py
+++ b/application/backend/app/api/endpoints/sinks.py
@@ -187,6 +187,58 @@ def delete_sink(project_id: UUID, sink_id: UUID, sink_service: SinkServiceDep) -
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
+@projects_router.put(
+    path="/{project_id}/sinks/{sink_id}/deactivate",
+    tags=["Sinks"],
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Sink deactivated successfully",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "id": "550e8400-e29b-41d4-a716-446655440000",
+                        "active": False,
+                        "config": {
+                            "sink_type": "mqtt",
+                            "name": "My MQTT Sink",
+                            "broker_host": "localhost",
+                            "broker_port": 1883,
+                            "topic": "predictions",
+                            "auth_required": True,
+                        },
+                    }
+                }
+            },
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Project or sink not found",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "project_missing": {
+                            "summary": "Project not found",
+                            "value": {"detail": "Project with ID 3fa85f64-5717-4562-b3fc-2c963f66afa6 not found."},
+                        },
+                        "sink_missing": {
+                            "summary": "Sink not found",
+                            "value": {"detail": "Sink with ID 04b34cb0-c405-4566-990a-4eaeeaaa515a not found."},
+                        },
+                    }
+                }
+            },
+        },
+    },
+)
+def deactivate_sink(
+    project_id: UUID, sink_id: UUID, sink_service: SinkServiceDep
+) -> SinkSchema:
+    """
+    Deactivate the specified project's sink configuration by setting active=False.
+    """
+    return sink_service.deactivate_sink(project_id=project_id, sink_id=sink_id)
+
+
 @projects_router.post(
     path="/{project_id}/sinks",
     tags=["Sinks"],

--- a/application/backend/app/domain/services/sink.py
+++ b/application/backend/app/domain/services/sink.py
@@ -233,6 +233,32 @@ class SinkService(BaseService):
             self._emit_component_change(project_id=project_id, sink_id=sink_id)
         logger.info(f"Sink deleted: sink_id={sink_id} project_id={project_id}")
 
+    def deactivate_sink(self, project_id: UUID, sink_id: UUID) -> SinkSchema:
+        """
+        Deactivate a sink by setting active=False.
+
+        Args:
+            project_id: UUID of the project.
+            sink_id: UUID of the sink.
+
+        Returns:
+            The updated sink schema with active=False.
+
+        Raises:
+            ResourceNotFoundError: If the project or sink does not exist.
+        """
+        self._ensure_project(project_id)
+        sink = self.sink_repository.get_by_id_and_project(sink_id, project_id)
+        if not sink:
+            logger.error(f"Cannot deactivate sink: sink_id={sink_id} not found in project_id={project_id}")
+            raise ResourceNotFoundError(resource_type=ResourceType.SINK, resource_id=str(sink_id))
+        with self.db_transaction():
+            sink.active = False
+            sink = self.sink_repository.update(sink)
+            self._emit_component_change(project_id=project_id, sink_id=sink.id)
+        logger.info(f"Sink deactivated: sink_id={sink_id} project_id={project_id}")
+        return sink_db_to_schema(sink)
+
     def _ensure_project(self, project_id: UUID) -> ProjectDB:
         """
         Ensure the project exists.

--- a/application/backend/tests/unit/api/endpoints/test_sinks.py
+++ b/application/backend/tests/unit/api/endpoints/test_sinks.py
@@ -231,7 +231,7 @@ def test_update_sink(client, behavior, expected_status):
         ("error", 500),
     ],
 )
-def test_delete_source(client, behavior, expected_status):
+def test_delete_sink(client, behavior, expected_status):
     class FakeService:
         def __init__(self, session, config_change_dispatcher):
             pass
@@ -253,5 +253,44 @@ def test_delete_source(client, behavior, expected_status):
     assert resp.status_code == expected_status
     if expected_status == 204:
         assert resp.text == ""
+    else:
+        assert "detail" in resp.json()
+
+
+@pytest.mark.parametrize(
+    "behavior,expected_status",
+    [
+        ("success", 200),
+        ("missing_sink", 404),
+        ("missing_project", 404),
+        ("error", 500),
+    ],
+)
+def test_deactivate_sink(client, behavior, expected_status):
+    class FakeService:
+        def __init__(self, session, config_change_dispatcher):
+            pass
+
+        def deactivate_sink(self, project_id: UUID, sink_id: UUID):
+            assert project_id == PROJECT_ID
+            assert sink_id == SINK_ID_1
+            if behavior == "success":
+                return make_sink_schema(sink_id=sink_id, active=False)
+            if behavior == "missing_sink":
+                raise ResourceNotFoundError(ResourceType.SINK, str(sink_id))
+            if behavior == "missing_project":
+                raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
+            if behavior == "error":
+                raise RuntimeError("Database error")
+            raise AssertionError("Unhandled behavior")
+
+    client.app.dependency_overrides[get_sink_service] = lambda: FakeService(None, None)
+
+    resp = client.put(f"/api/v1/projects/{PROJECT_ID}/sinks/{SINK_ID_1}/deactivate")
+    assert resp.status_code == expected_status
+    if behavior == "success":
+        data = resp.json()
+        assert data["id"] == str(SINK_ID_1)
+        assert data["active"] is False
     else:
         assert "detail" in resp.json()

--- a/application/backend/tests/unit/domain/services/test_sink.py
+++ b/application/backend/tests/unit/domain/services/test_sink.py
@@ -600,6 +600,96 @@ class TestDeleteSink:
         assert exc_info.value.resource_type == ResourceType.PROJECT
 
 
+class TestDeactivateSink:
+    """Tests for deactivate_sink method."""
+
+    def test_deactivate_sink_success(
+        self,
+        sink_service,
+        mock_project_repository,
+        mock_sink_repository,
+        mock_session,
+        mock_dispatcher,
+        project_id,
+        sink_id,
+        mock_project,
+        mock_sink,
+    ):
+        """Test successfully deactivating a sink."""
+        # Arrange
+        mock_sink.active = True  # start as active
+        mock_project_repository.get_by_id.return_value = mock_project
+        mock_sink_repository.get_by_id_and_project.return_value = mock_sink
+        mock_sink_repository.update.return_value = mock_sink
+
+        # Act
+        result = sink_service.deactivate_sink(project_id, sink_id)
+
+        # Assert
+        assert isinstance(result, SinkSchema)
+        assert result.active is False
+        assert mock_sink.active is False
+        mock_sink_repository.update.assert_called_once_with(mock_sink)
+        mock_session.commit.assert_called_once()
+
+    def test_deactivate_sink_already_inactive(
+        self,
+        sink_service,
+        mock_project_repository,
+        mock_sink_repository,
+        project_id,
+        sink_id,
+        mock_project,
+        mock_sink,
+    ):
+        """Test deactivating a sink that is already inactive."""
+        # Arrange
+        mock_sink.active = False  # already inactive
+        mock_project_repository.get_by_id.return_value = mock_project
+        mock_sink_repository.get_by_id_and_project.return_value = mock_sink
+        mock_sink_repository.update.return_value = mock_sink
+
+        # Act
+        result = sink_service.deactivate_sink(project_id, sink_id)
+
+        # Assert
+        assert result.active is False
+
+    def test_deactivate_sink_not_found(
+        self,
+        sink_service,
+        mock_project_repository,
+        mock_sink_repository,
+        project_id,
+        sink_id,
+        mock_project,
+    ):
+        """Test deactivating a sink that doesn't exist."""
+        # Arrange
+        mock_project_repository.get_by_id.return_value = mock_project
+        mock_sink_repository.get_by_id_and_project.return_value = None
+
+        # Act & Assert
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            sink_service.deactivate_sink(project_id, sink_id)
+
+        assert exc_info.value.resource_type == ResourceType.SINK
+        assert exc_info.value.resource_id == str(sink_id)
+
+    def test_deactivate_sink_project_not_found(
+        self, sink_service, mock_project_repository, project_id, sink_id
+    ):
+        """Test deactivating a sink when project doesn't exist."""
+        # Arrange
+        mock_project_repository.get_by_id.return_value = None
+
+        # Act & Assert
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            sink_service.deactivate_sink(project_id, sink_id)
+
+        assert exc_info.value.resource_type == ResourceType.PROJECT
+
+
 class TestEventDispatcher:
     """Tests for event dispatcher integration."""
 
@@ -680,6 +770,33 @@ class TestEventDispatcher:
         event = mock_dispatcher.dispatch.call_args[0][0]
         assert isinstance(event, ComponentConfigChangeEvent)
         assert event.component_type == ComponentType.SINK
+
+    def test_deactivate_sink_emits_event(
+        self,
+        sink_service,
+        mock_project_repository,
+        mock_sink_repository,
+        mock_dispatcher,
+        project_id,
+        sink_id,
+        mock_project,
+        mock_sink,
+    ):
+        """Test that deactivating a sink emits a component change event."""
+        # Arrange
+        mock_project_repository.get_by_id.return_value = mock_project
+        mock_sink_repository.get_by_id_and_project.return_value = mock_sink
+        mock_sink_repository.update.return_value = mock_sink
+
+        # Act
+        sink_service.deactivate_sink(project_id, sink_id)
+
+        # Assert
+        mock_dispatcher.dispatch.assert_called_once()
+        event = mock_dispatcher.dispatch.call_args[0][0]
+        assert isinstance(event, ComponentConfigChangeEvent)
+        assert event.component_type == ComponentType.SINK
+        assert event.component_id == sink_id
 
     def test_no_dispatcher_does_not_raise(
         self,


### PR DESCRIPTION
# Pull Request

## Description
This PR enables the users to manually control the operational state of sinks. Specifically, it implements `deactivate_sink` endpoint, an alternative to `delete_sink` to stop a sink but persist its updated state in the DB rather than deleting it, thus deactivating the sink. This ensures users can reactivate the sink using the already available `update_sink` endpoint instead of creating a new one. 

## Type of Change

- [x] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues
[open-edge-platform/geti-instant-learn#1020](https://github.com/open-edge-platform/geti-instant-learn/issues/1020)

## Breaking Changes

