### PR TITLE
feat: implement scene-change-aware frame skipping

### DIFF
--- a/application/backend/app/runtime/components.py
+++ b/application/backend/app/runtime/components.py
@@ -57,6 +57,7 @@ class DefaultComponentFactory(ComponentFactory):
             batch_size=settings.processor_batch_size,
             frame_skip_interval=settings.processor_frame_skip_interval,
             frame_skip_amount=settings.processor_frame_skip_amount,
+            scene_detection_threshold=settings.processor_scene_detection_threshold,
         )
 
     def create_sink(self, writer_cfg: WriterConfig | None) -> Sink:

--- a/application/backend/app/runtime/core/components/processor.py
+++ b/application/backend/app/runtime/core/components/processor.py
@@ -37,7 +37,7 @@ class FrameSkipPolicy:
     Raises:
         ValueError: If frame_skip_interval is negative.
     """
-    def __init__(self, interval: int = 3, skip_amount: int = 1, scene_detector: SceneChangeDetector | None = None) -> None:
+    def __init__(self, interval: int = 3, skip_amount: int = 1, scene_detector_threshold: float | None = None) -> None:
         if interval < 0 or interval == 1:
             raise ValueError(f"frame_skip_interval must be > 1 or 0 for no skipping, got {interval}")
         if interval > 0 and (skip_amount < 0 or skip_amount >= interval):
@@ -45,7 +45,8 @@ class FrameSkipPolicy:
         self._interval = interval
         self._skip_amount = skip_amount
         self._counter = 0
-        self._scene_detector = scene_detector
+        self._scene_detector_threshold = scene_detector_threshold
+        self._scene_detector = SceneChangeDetector(threshold=scene_detector_threshold) if scene_detector_threshold is not None else None
 
     @property
     def interval(self) -> int:
@@ -104,9 +105,8 @@ class Processor(PipelineComponent):
         super().__init__()
         self._model_handler = model_handler
         self._batch_size = batch_size
-        scene_detector = SceneChangeDetector(threshold=scene_detection_threshold) if scene_detection_threshold is not None else None
         self._skip_policy = FrameSkipPolicy(
-            interval=frame_skip_interval, skip_amount=frame_skip_amount, scene_detector=scene_detector
+            interval=frame_skip_interval, skip_amount=frame_skip_amount, scene_detector_threshold=scene_detection_threshold
         )
         self._initialized = False
 
@@ -127,10 +127,11 @@ class Processor(PipelineComponent):
 
         self._model_handler.initialise()
         logger.info(
-            "Pipeline model handler initialized, batch size: %d, frame skip interval: %d, skip amount: %d",
+            "Pipeline model handler initialized, batch size: %d, frame skip interval: %d, skip amount: %d, scene detection threshold: %s",
             self._batch_size,
             self._skip_policy.interval,
             self._skip_policy.skip_amount,
+            self._skip_policy._scene_detector_threshold if self._skip_policy._scene_detector_threshold is not None else "None",
         )
 
         while not self._stop_event.is_set():

--- a/application/backend/app/runtime/core/components/processor.py
+++ b/application/backend/app/runtime/core/components/processor.py
@@ -99,12 +99,12 @@ class Processor(PipelineComponent):
         batch_size: int = 1,
         frame_skip_interval: int = 3,
         frame_skip_amount: int = 1,
-        enable_scene_detector: bool = False,
+        scene_detection_threshold: float | None = None,
     ) -> None:
         super().__init__()
         self._model_handler = model_handler
         self._batch_size = batch_size
-        scene_detector = SceneChangeDetector() if enable_scene_detector else None
+        scene_detector = SceneChangeDetector(threshold=scene_detection_threshold) if scene_detection_threshold is not None else None
         self._skip_policy = FrameSkipPolicy(
             interval=frame_skip_interval, skip_amount=frame_skip_amount, scene_detector=scene_detector
         )

--- a/application/backend/app/runtime/core/components/processor.py
+++ b/application/backend/app/runtime/core/components/processor.py
@@ -24,19 +24,22 @@ class FrameSkipPolicy:
         Process frames 1..N-1, drop frame N, repeat.
         Example (N=3): process, process, DROP, process, process, DROP, ...
     
-    If interval is 0, no frames are ever skipped.
+    If interval is 0 or skip_amount is 0, no frames are ever skipped by the cyclic policy.    
     
-    If a scene_detector is configured, a detected scene change overrides
-    this pattern and forces the frame to be processed.
+    If scene_detector_threshold is configured, a detected scene change overrides
+    the cyclic decision and forces the frame to be processed. If the cyclic
+    policy is disabled (interval or skip_amount is 0), scene detection becomes
+    the sole skip decision: frames with no detected scene change are skipped.
     
     Args:
         interval: Total cycle length (process and skip). 0 disables skipping.
         skip_amount: Number of consecutive frames to skip per cycle. Must be < interval.
-        scene_detector: Optional detector whose scene-change signal overrides the cyclic decision.
+        scene_detector_threshold: Optional threshold for scene change detection.
     
     Raises:
         ValueError: If frame_skip_interval is negative.
     """
+
     def __init__(self, interval: int = 3, skip_amount: int = 1, scene_detector_threshold: float | None = None) -> None:
         if interval < 0 or interval == 1:
             raise ValueError(f"frame_skip_interval must be > 1 or 0 for no skipping, got {interval}")
@@ -66,19 +69,22 @@ class FrameSkipPolicy:
         return position >= process_count
 
     def should_skip(self, frame: np.ndarray | None = None) -> bool:
-        """
-        Return True if the current frame should be dropped.
-
-        If a scene_detector is configured, a detected scene-change always
-        forces processing (skip=False). It overrides the cyclic decision
-        but does not alter the cyclic counter's own state.
-        """
+        """Return True or False indicating whether the current frame should be skipped."""
         cyclic_skip = self._cyclic_should_skip()
 
         if self._scene_detector is not None and frame is not None:
-            if self._scene_detector.is_new_scene(frame):
-                return False  # new scene overrides the cyclic verdict
+            cyclic_disabled = self._interval == 0 or self._skip_amount == 0
+            is_new_scene = self._scene_detector.is_new_scene(frame)
 
+            if cyclic_disabled:
+                logger.info("%s Frame: Scene-detector-only policy", "PROCESS" if is_new_scene else "SKIP")
+                return not is_new_scene
+
+            if is_new_scene:
+                logger.info("PROCESS Frame: Scene change detected")
+                return False
+
+        logger.info("%s Frame: Cyclic policy", "SKIP" if cyclic_skip else "PROCESS")
         return cyclic_skip
 
     def reset(self) -> None:

--- a/application/backend/app/runtime/core/components/processor.py
+++ b/application/backend/app/runtime/core/components/processor.py
@@ -9,6 +9,7 @@ import numpy as np
 from domain.services.schemas.processor import ErrorData, InputData, OutputData
 from runtime.core.components.base import ModelHandler, PipelineComponent
 from runtime.core.components.broadcaster import FrameBroadcaster
+from runtime.core.components.scene_change import SceneChangeDetector
 
 logger = logging.getLogger(__name__)
 
@@ -17,23 +18,26 @@ EMPTY_RESULT: dict[str, np.ndarray] = {}
 
 class FrameSkipPolicy:
     """
-    Decides whether to skip (drop) a frame based on a cyclic counter.
+    Decides whether to skip (drop) a frame based on a cyclic counter or scene-change detection.
 
-    Skip pattern with interval N (N >= 1):
+    Cyclic skip pattern with interval N (N >= 1):
         Process frames 1..N-1, drop frame N, repeat.
         Example (N=3): process, process, DROP, process, process, DROP, ...
-
+    
     If interval is 0, no frames are ever skipped.
-
+    
+    If a scene_detector is configured, a detected scene change overrides
+    this pattern and forces the frame to be processed.
+    
     Args:
         interval: Total cycle length (process and skip). 0 disables skipping.
         skip_amount: Number of consecutive frames to skip per cycle. Must be < interval.
-
+        scene_detector: Optional detector whose scene-change signal overrides the cyclic decision.
+    
     Raises:
         ValueError: If frame_skip_interval is negative.
     """
-
-    def __init__(self, interval: int = 3, skip_amount: int = 1) -> None:
+    def __init__(self, interval: int = 3, skip_amount: int = 1, scene_detector: SceneChangeDetector | None = None) -> None:
         if interval < 0 or interval == 1:
             raise ValueError(f"frame_skip_interval must be > 1 or 0 for no skipping, got {interval}")
         if interval > 0 and (skip_amount < 0 or skip_amount >= interval):
@@ -41,6 +45,7 @@ class FrameSkipPolicy:
         self._interval = interval
         self._skip_amount = skip_amount
         self._counter = 0
+        self._scene_detector = scene_detector
 
     @property
     def interval(self) -> int:
@@ -50,17 +55,30 @@ class FrameSkipPolicy:
     def skip_amount(self) -> int:
         return self._skip_amount
 
-    def should_skip(self) -> bool:
-        """Return True if the current frame should be dropped. Advances the internal counter on every call."""
+    def _cyclic_should_skip(self) -> bool:
+        """Cyclic frame skipping based on the configured interval and skip amount."""
         if self._interval == 0 or self._skip_amount == 0:
             return False
-
         position = self._counter % self._interval
         self._counter += 1
-
-        # process the first (interval - skip_count) frames, skip the rest
         process_count = self._interval - self._skip_amount
         return position >= process_count
+
+    def should_skip(self, frame: np.ndarray | None = None) -> bool:
+        """
+        Return True if the current frame should be dropped.
+
+        If a scene_detector is configured, a detected scene-change always
+        forces processing (skip=False). It overrides the cyclic decision
+        but does not alter the cyclic counter's own state.
+        """
+        cyclic_skip = self._cyclic_should_skip()
+
+        if self._scene_detector is not None and frame is not None:
+            if self._scene_detector.is_new_scene(frame):
+                return False  # new scene overrides the cyclic verdict
+
+        return cyclic_skip
 
     def reset(self) -> None:
         """Reset the internal counter."""
@@ -76,12 +94,20 @@ class Processor(PipelineComponent):
     """
 
     def __init__(
-        self, model_handler: ModelHandler, batch_size: int = 1, frame_skip_interval: int = 3, frame_skip_amount: int = 1
+        self,
+        model_handler: ModelHandler,
+        batch_size: int = 1,
+        frame_skip_interval: int = 3,
+        frame_skip_amount: int = 1,
+        enable_scene_detector: bool = False,
     ) -> None:
         super().__init__()
         self._model_handler = model_handler
         self._batch_size = batch_size
-        self._skip_policy = FrameSkipPolicy(interval=frame_skip_interval, skip_amount=frame_skip_amount)
+        scene_detector = SceneChangeDetector() if enable_scene_detector else None
+        self._skip_policy = FrameSkipPolicy(
+            interval=frame_skip_interval, skip_amount=frame_skip_amount, scene_detector=scene_detector
+        )
         self._initialized = False
 
     def setup(
@@ -153,12 +179,16 @@ class Processor(PipelineComponent):
                         break
                     continue
 
+            if isinstance(input_data, ErrorData):
+                self._outbound_broadcaster.broadcast(input_data)
+                continue
+
             if input_data.trace:
                 input_data.trace.record_start("processor")
 
             is_manual = input_data.context.get("requires_manual_control", False)
 
-            if not is_manual and self._skip_policy.should_skip():
+            if not is_manual and self._skip_policy.should_skip(input_data.frame):
                 continue
 
             batch_data.append(input_data)

--- a/application/backend/app/runtime/core/components/scene_change.py
+++ b/application/backend/app/runtime/core/components/scene_change.py
@@ -1,0 +1,127 @@
+#  Copyright (C) 2025 Intel Corporation
+#  SPDX-License-Identifier: Apache-2.0
+
+"""Content-aware scene change detection using difference hash (dHash).
+
+dHash overview:
+    1. Convert the frame to grayscale and downsample to a (hash_size, hash_size + 1)
+       thumbnail (default 8x9 -> 64-bit hash).
+    2. For each row, compare each adjacent pair of pixels -> 64 boolean bits.
+    3. Pack the bits into a single integer (the hash).
+    4. Two frames are "the same scene" when the normalized Hamming distance between
+       their hashes is <= a configurable threshold.
+"""
+
+import numpy as np
+
+# Luminance weights for RGB -> grayscale (ITU-R BT.601).
+_RGB_TO_GRAY = np.array([0.299, 0.587, 0.114], dtype=np.float32)
+
+
+def _to_grayscale(frame: np.ndarray) -> np.ndarray:
+    """Convert an RGB HWC frame to a 2D grayscale array. Pass 2D input through unchanged."""
+    if frame.ndim == 2:
+        return frame.astype(np.float32)
+    if frame.ndim == 3 and frame.shape[2] >= 3:
+        return frame[:, :, :3].astype(np.float32) @ _RGB_TO_GRAY
+    raise ValueError(f"Expected an HWC RGB frame or a 2D grayscale array, got shape {frame.shape}")
+
+
+def _resize_nearest(gray: np.ndarray, out_h: int, out_w: int) -> np.ndarray:
+    """Nearest-neighbor downsample of a 2D array to (out_h, out_w). Dependency-free."""
+    h, w = gray.shape
+    if h == 0 or w == 0:
+        raise ValueError(f"Cannot resize an empty frame with shape {gray.shape}")
+    row_idx = (np.arange(out_h) * h) // out_h
+    col_idx = (np.arange(out_w) * w) // out_w
+    return gray[row_idx][:, col_idx]
+
+
+def dhash(frame: np.ndarray, hash_size: int = 8) -> int:
+    """Compute the difference hash of a frame.
+
+    Args:
+        frame: RGB HWC uint8 frame (H, W, 3) or a 2D grayscale array.
+        hash_size: Number of rows/columns in the comparison grid. Produces a
+            hash_size * hash_size bit hash (default 8 -> 64 bits).
+
+    Returns:
+        The dHash as a non-negative integer.
+
+    Raises:
+        ValueError: If hash_size < 1 or the frame shape is unsupported.
+    """
+    if hash_size < 1:
+        raise ValueError(f"hash_size must be >= 1, got {hash_size}")
+
+    gray = _to_grayscale(frame)
+    # Width is one larger than height so adjacent-column diffs yield hash_size columns.
+    small = _resize_nearest(gray, hash_size, hash_size + 1)
+    diff = small[:, 1:] > small[:, :-1]  # (hash_size, hash_size) boolean grid
+
+    # Pack the row-major bit grid into a single integer.
+    value = 0
+    for bit in diff.flatten():
+        value = (value << 1) | int(bit)
+    return value
+
+
+def hamming_distance(hash_a: int, hash_b: int) -> int:
+    """Number of differing bits between two hashes."""
+    return int(bin(hash_a ^ hash_b).count("1"))
+
+
+class SceneChangeDetector:
+    """Tracks the last processed frame's dHash and decides whether a new frame is a new scene.
+
+    A frame is considered a *new scene* (and therefore worth processing) when the
+    normalized Hamming distance to the last processed frame exceeds ``threshold``.
+    The first frame seen is always a new scene.
+
+    Args:
+        threshold: Normalized Hamming distance (0..1) at or below which two frames are
+            treated as the same scene. Default 0.1 (<= ~6 bits for a 64-bit hash).
+        hash_size: dHash grid size; ``hash_size * hash_size`` bits total.
+
+    Raises:
+        ValueError: If threshold is outside [0, 1] or hash_size < 1.
+    """
+
+    def __init__(self, threshold: float = 0.1, hash_size: int = 8) -> None:
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError(f"threshold must be in [0, 1], got {threshold}")
+        if hash_size < 1:
+            raise ValueError(f"hash_size must be >= 1, got {hash_size}")
+        self._threshold = threshold
+        self._hash_size = hash_size
+        self._bits = hash_size * hash_size
+        self._last_hash: int | None = None
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    @property
+    def last_hash(self) -> int | None:
+        return self._last_hash
+
+    def is_new_scene(self, frame: np.ndarray) -> bool:
+        """Return True if the frame differs enough from the last processed frame to be a new scene.
+
+        Updates the stored hash only when a new scene is detected, so slow drift across
+        many near-duplicate frames is always measured against the last *committed* scene.
+        """
+        current = dhash(frame, hash_size=self._hash_size)
+        if self._last_hash is None:
+            self._last_hash = current
+            return True
+
+        normalized = hamming_distance(current, self._last_hash) / self._bits
+        if normalized > self._threshold:
+            self._last_hash = current
+            return True
+        return False
+
+    def reset(self) -> None:
+        """Forget the last processed frame so the next frame is treated as a new scene."""
+        self._last_hash = None

--- a/application/backend/app/runtime/core/components/scene_change.py
+++ b/application/backend/app/runtime/core/components/scene_change.py
@@ -11,8 +11,11 @@ dHash overview:
     4. Two frames are "the same scene" when the normalized Hamming distance between
        their hashes is <= a configurable threshold.
 """
+import logging
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # Luminance weights for RGB -> grayscale (ITU-R BT.601).
 _RGB_TO_GRAY = np.array([0.299, 0.587, 0.114], dtype=np.float32)
@@ -80,14 +83,14 @@ class SceneChangeDetector:
 
     Args:
         threshold: Normalized Hamming distance (0..1) at or below which two frames are
-            treated as the same scene. Default 0.1 (<= ~6 bits for a 64-bit hash).
+            treated as the same scene. Default 0.5 (<= ~32 bits for a 64-bit hash).
         hash_size: dHash grid size; ``hash_size * hash_size`` bits total.
 
     Raises:
         ValueError: If threshold is outside [0, 1] or hash_size < 1.
     """
 
-    def __init__(self, threshold: float = 0.1, hash_size: int = 8) -> None:
+    def __init__(self, threshold: float = 0.5, hash_size: int = 8) -> None:
         if not 0.0 <= threshold <= 1.0:
             raise ValueError(f"threshold must be in [0, 1], got {threshold}")
         if hash_size < 1:
@@ -117,6 +120,7 @@ class SceneChangeDetector:
             return True
 
         normalized = hamming_distance(current, self._last_hash) / self._bits
+        logger.debug("Normalized Hamming Distance: %.4f, Threshold: %.4f", normalized, self._threshold)
         if normalized > self._threshold:
             self._last_hash = current
             return True

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -136,7 +136,7 @@ class Settings(BaseSettings):
     processor_frame_skip_interval: int = Field(default=3, ge=0, alias="PROCESSOR_FRAME_SKIP_INTERVAL")
     processor_frame_skip_amount: int = Field(default=2, ge=0, alias="PROCESSOR_FRAME_SKIP_AMOUNT")
     processor_scene_detection_threshold: float | None = Field(
-        default=0.5, ge=0.0, le=1.0, alias="PROCESSOR_SCENE_DETECTION_THRESHOLD"
+        default=0.1, ge=0.0, le=1.0, alias="PROCESSOR_SCENE_DETECTION_THRESHOLD"
     )
     processor_inference_enabled: bool = Field(default=True, alias="PROCESSOR_INFERENCE_ENABLED")
     processor_openvino_enabled: bool = Field(default=True, alias="PROCESSOR_OPENVINO_ENABLED")

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -17,8 +17,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Application settings with environment variable support"""
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore")
-
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore",
+        env_parse_none_str="null",
+    )
     current_dir: Path = Path(__file__).parent.resolve()
 
     # Application
@@ -133,6 +135,9 @@ class Settings(BaseSettings):
     processor_batch_size: int = Field(default=1, alias="PROCESSOR_BATCH_SIZE")
     processor_frame_skip_interval: int = Field(default=3, ge=0, alias="PROCESSOR_FRAME_SKIP_INTERVAL")
     processor_frame_skip_amount: int = Field(default=2, ge=0, alias="PROCESSOR_FRAME_SKIP_AMOUNT")
+    processor_scene_detection_threshold: float | None = Field(
+        default=0.5, ge=0.0, le=1.0, alias="PROCESSOR_SCENE_DETECTION_THRESHOLD"
+    )
     processor_inference_enabled: bool = Field(default=True, alias="PROCESSOR_INFERENCE_ENABLED")
     processor_openvino_enabled: bool = Field(default=True, alias="PROCESSOR_OPENVINO_ENABLED")
 

--- a/application/backend/tests/unit/runtime/core/components/test_processor.py
+++ b/application/backend/tests/unit/runtime/core/components/test_processor.py
@@ -14,6 +14,7 @@ from domain.services.schemas.processor import ErrorData, InputData, OutputData
 from runtime.core.components.base import ModelHandler
 from runtime.core.components.broadcaster import FrameBroadcaster
 from runtime.core.components.processor import FrameSkipPolicy, Processor
+from runtime.core.components.scene_change import SceneChangeDetector
 
 
 def make_input_data(requires_manual_control: bool = False, with_trace: bool = False) -> InputData:
@@ -131,6 +132,88 @@ class TestFrameSkipPolicy:
     def test_skip_amount_property(self) -> None:
         policy = FrameSkipPolicy(interval=5, skip_amount=2)
         assert policy.skip_amount == 2
+
+    def test_scene_change_forces_processing_over_skip(self) -> None:
+        """When scene detector reports a change, frame is processed even if cyclic says skip."""
+        scene_detector = Mock(spec=SceneChangeDetector)
+        scene_detector.is_new_scene.return_value = True  # force scene change on every call
+
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+
+        # Advance counter to position where cyclic would skip (position 2)
+        policy.should_skip(np.zeros((64, 64, 3)))  # pos 0 -> False
+        policy.should_skip(np.zeros((64, 64, 3)))  # pos 1 -> False
+        result = policy.should_skip(np.zeros((64, 64, 3)))  # pos 2 would be True (skip)
+
+        assert result is False  # scene change overrides the skip
+        scene_detector.is_new_scene.assert_called()
+
+    def test_scene_change_does_not_alter_cyclic_counter(self) -> None:
+        """Scene detection override should not affect the cyclic counter's own state."""
+        scene_detector = Mock(spec=SceneChangeDetector)
+        scene_detector.is_new_scene.return_value = True  # always force processing
+
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+
+        # Call should_skip multiple times with scene changes forcing processing
+        for _ in range(6):
+            policy.should_skip(np.zeros((64, 64, 3)))
+
+        # Counter should have advanced normally (6 increments)
+        assert policy._counter == 6
+
+        # Next cycle should still follow the pattern: process, process, DROP
+        result = policy.should_skip(np.zeros((64, 64, 3)))  # pos 0 -> False
+        assert result is False
+        result = policy.should_skip(np.zeros((64, 64, 3)))  # pos 1 -> False
+        assert result is False
+        result = policy.should_skip(np.zeros((64, 64, 3)))  # pos 2 -> True (skip) but overridden
+        assert result is False  # still overridden by scene change
+
+    def test_no_scene_change_falls_back_to_cyclic(self) -> None:
+        """When scene detector reports no change, cyclic decision applies normally."""
+        scene_detector = Mock(spec=SceneChangeDetector)
+        scene_detector.is_new_scene.return_value = False  # no scene change
+
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+
+        results = [policy.should_skip(np.zeros((64, 64, 3))) for _ in range(6)]
+        assert results == [False, False, True, False, False, True]
+
+    def test_scene_detector_not_called_when_frame_is_none(self) -> None:
+        """Scene detector should not be called if frame is None."""
+        scene_detector = Mock(spec=SceneChangeDetector)
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+
+        # Call with None frame - should not invoke the detector
+        result = policy.should_skip(frame=None)
+
+        assert result is False  # no frame means no scene change detection
+        scene_detector.is_new_scene.assert_not_called()
+
+    def test_no_scene_detector_ignores_frame_argument(self) -> None:
+        """When no scene detector is configured, the frame argument is ignored."""
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=None)
+
+        results = [policy.should_skip(np.zeros((64, 64, 3))) for _ in range(6)]
+        assert results == [False, False, True, False, False, True]
+
+    def test_scene_change_in_middle_of_cycle_resets_expectation(self) -> None:
+        """Scene change during a skip position allows processing but counter continues."""
+        scene_detector = Mock(spec=SceneChangeDetector)
+
+        # First 2 frames: no scene change (process)
+        # 3rd frame: scene change (would be skipped, but overridden)
+        # 4th frame: no scene change (process, start of new cycle)
+        scene_detector.is_new_scene.side_effect = [False, False, True, False]
+
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+
+        results = [policy.should_skip(np.zeros((64, 64, 3))) for _ in range(4)]
+        assert results == [False, False, False, False]  # all processed due to overrides
+
+        # Verify is_new_scene was called the expected number of times
+        assert scene_detector.is_new_scene.call_count == 4
 
 
 class TestProcessorInit:

--- a/application/backend/tests/unit/runtime/core/components/test_processor.py
+++ b/application/backend/tests/unit/runtime/core/components/test_processor.py
@@ -135,10 +135,11 @@ class TestFrameSkipPolicy:
 
     def test_scene_change_forces_processing_over_skip(self) -> None:
         """When scene detector reports a change, frame is processed even if cyclic says skip."""
-        scene_detector = Mock(spec=SceneChangeDetector)
-        scene_detector.is_new_scene.return_value = True  # force scene change on every call
+        fake_scene_detector = Mock(spec=SceneChangeDetector)
+        fake_scene_detector.is_new_scene.return_value = True  # force scene change on every call
 
-        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector_threshold=0.5)
+        policy._scene_detector = fake_scene_detector  # inject mock scene detector
 
         # Advance counter to position where cyclic would skip (position 2)
         policy.should_skip(np.zeros((64, 64, 3)))  # pos 0 -> False
@@ -146,14 +147,15 @@ class TestFrameSkipPolicy:
         result = policy.should_skip(np.zeros((64, 64, 3)))  # pos 2 would be True (skip)
 
         assert result is False  # scene change overrides the skip
-        scene_detector.is_new_scene.assert_called()
+        policy._scene_detector.is_new_scene.assert_called()
 
     def test_scene_change_does_not_alter_cyclic_counter(self) -> None:
         """Scene detection override should not affect the cyclic counter's own state."""
-        scene_detector = Mock(spec=SceneChangeDetector)
-        scene_detector.is_new_scene.return_value = True  # always force processing
+        fake_scene_detector = Mock(spec=SceneChangeDetector)
+        fake_scene_detector.is_new_scene.return_value = True  # always force processing
 
-        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector_threshold=0.5)
+        policy._scene_detector = fake_scene_detector  # inject mock scene detector
 
         # Call should_skip multiple times with scene changes forcing processing
         for _ in range(6):
@@ -172,48 +174,62 @@ class TestFrameSkipPolicy:
 
     def test_no_scene_change_falls_back_to_cyclic(self) -> None:
         """When scene detector reports no change, cyclic decision applies normally."""
-        scene_detector = Mock(spec=SceneChangeDetector)
-        scene_detector.is_new_scene.return_value = False  # no scene change
+        fake_scene_detector = Mock(spec=SceneChangeDetector)
+        fake_scene_detector.is_new_scene.return_value = False  # no scene change
 
-        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector_threshold=0.5)
+        policy._scene_detector = fake_scene_detector  # inject mock scene detector
 
         results = [policy.should_skip(np.zeros((64, 64, 3))) for _ in range(6)]
         assert results == [False, False, True, False, False, True]
 
     def test_scene_detector_not_called_when_frame_is_none(self) -> None:
         """Scene detector should not be called if frame is None."""
-        scene_detector = Mock(spec=SceneChangeDetector)
-        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+        fake_scene_detector = Mock(spec=SceneChangeDetector)
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector_threshold=0.5)
+        policy._scene_detector = fake_scene_detector  # inject mock scene detector
 
         # Call with None frame - should not invoke the detector
         result = policy.should_skip(frame=None)
 
         assert result is False  # no frame means no scene change detection
-        scene_detector.is_new_scene.assert_not_called()
+        policy._scene_detector.is_new_scene.assert_not_called()
 
     def test_no_scene_detector_ignores_frame_argument(self) -> None:
         """When no scene detector is configured, the frame argument is ignored."""
-        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=None)
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector_threshold=None)
 
         results = [policy.should_skip(np.zeros((64, 64, 3))) for _ in range(6)]
         assert results == [False, False, True, False, False, True]
 
     def test_scene_change_in_middle_of_cycle_resets_expectation(self) -> None:
         """Scene change during a skip position allows processing but counter continues."""
-        scene_detector = Mock(spec=SceneChangeDetector)
+        fake_scene_detector = Mock(spec=SceneChangeDetector)
 
-        # First 2 frames: no scene change (process)
-        # 3rd frame: scene change (would be skipped, but overridden)
-        # 4th frame: no scene change (process, start of new cycle)
-        scene_detector.is_new_scene.side_effect = [False, False, True, False]
+        # First 2 frames: no scene change (cyclic says process)
+        # 3rd frame: scene change (cyclic says skipped, but overridden)
+        # 4th frame: no scene change (cyclic says process, start of new cycle)
+        fake_scene_detector.is_new_scene.side_effect = [False, False, True, False]
 
-        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector=scene_detector)
+        policy = FrameSkipPolicy(interval=3, skip_amount=1, scene_detector_threshold=0.5)
+        policy._scene_detector = fake_scene_detector  # inject mock scene detector
 
         results = [policy.should_skip(np.zeros((64, 64, 3))) for _ in range(4)]
         assert results == [False, False, False, False]  # all processed due to overrides
 
         # Verify is_new_scene was called the expected number of times
-        assert scene_detector.is_new_scene.call_count == 4
+        assert policy._scene_detector.is_new_scene.call_count == 4
+
+    def test_scene_change_with_skip_amount_zero(self) -> None:
+        """When skip_amount is zero, scene detection solely determines processing."""
+        fake_scene_detector = Mock(spec=SceneChangeDetector)
+        fake_scene_detector.is_new_scene.return_value = True  # always force processing
+
+        policy = FrameSkipPolicy(interval=3, skip_amount=0, scene_detector_threshold=0.5)
+        policy._scene_detector = fake_scene_detector  # inject mock scene detector
+
+        results = [policy.should_skip(np.zeros((64, 64, 3))) for _ in range(6)]
+        assert results == [False, False, False, False, False, False]  # all processed
 
 
 class TestProcessorInit:

--- a/application/backend/tests/unit/runtime/core/components/test_scene_change.py
+++ b/application/backend/tests/unit/runtime/core/components/test_scene_change.py
@@ -1,0 +1,145 @@
+#  Copyright (C) 2025 Intel Corporation
+#  SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from runtime.core.components.scene_change import (
+    SceneChangeDetector,
+    dhash,
+    hamming_distance,
+)
+
+
+def make_frame(seed: int, shape: tuple[int, int, int] = (120, 160, 3)) -> np.ndarray:
+    """Create a deterministic random RGB HWC uint8 frame."""
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 256, shape, dtype=np.uint8)
+
+
+def add_noise(frame: np.ndarray, amplitude: int, seed: int) -> np.ndarray:
+    """Return a near-duplicate of frame with small per-pixel noise added."""
+    rng = np.random.default_rng(seed)
+    noise = rng.integers(-amplitude, amplitude + 1, frame.shape)
+    return np.clip(frame.astype(int) + noise, 0, 255).astype(np.uint8)
+
+
+class TestDhash:
+    def test_identical_frames_have_equal_hash(self) -> None:
+        frame = make_frame(seed=1)
+        assert dhash(frame) == dhash(frame.copy())
+
+    def test_default_hash_uses_64_bits(self) -> None:
+        # A 8x8 grid hash must fit in 64 bits.
+        value = dhash(make_frame(seed=2))
+        assert 0 <= value < (1 << 64)
+
+    def test_hash_size_controls_bit_width(self) -> None:
+        # hash_size=4 -> 16-bit hash.
+        value = dhash(make_frame(seed=3), hash_size=4)
+        assert 0 <= value < (1 << 16)
+
+    def test_distinct_frames_have_different_hash(self) -> None:
+        assert dhash(make_frame(seed=4)) != dhash(make_frame(seed=5))
+
+    def test_grayscale_input_supported(self) -> None:
+        gray = make_frame(seed=6)[:, :, 0]  # 2D array
+        assert isinstance(dhash(gray), int)
+
+    def test_constant_frame_hash_is_zero(self) -> None:
+        # No adjacent-pixel differences -> all bits zero.
+        flat = np.full((120, 160, 3), 128, dtype=np.uint8)
+        assert dhash(flat) == 0
+
+    @pytest.mark.parametrize("hash_size", [0, -1])
+    def test_invalid_hash_size_raises(self, hash_size: int) -> None:
+        with pytest.raises(ValueError):
+            dhash(make_frame(seed=7), hash_size=hash_size)
+
+    def test_unsupported_shape_raises(self) -> None:
+        with pytest.raises(ValueError):
+            dhash(np.zeros((4, 4, 4, 3), dtype=np.uint8))
+
+
+class TestHammingDistance:
+    def test_equal_hashes_distance_zero(self) -> None:
+        assert hamming_distance(0b1010, 0b1010) == 0
+
+    def test_counts_differing_bits(self) -> None:
+        assert hamming_distance(0b0000, 0b1011) == 3
+
+    def test_symmetric(self) -> None:
+        assert hamming_distance(123, 456) == hamming_distance(456, 123)
+
+
+class TestSceneChangeDetector:
+    def test_first_frame_is_always_new_scene(self) -> None:
+        detector = SceneChangeDetector(threshold=0.1)
+        assert detector.is_new_scene(make_frame(seed=1)) is True
+
+    def test_identical_frame_is_same_scene(self) -> None:
+        detector = SceneChangeDetector(threshold=0.1)
+        frame = make_frame(seed=1)
+        detector.is_new_scene(frame)
+        assert detector.is_new_scene(frame.copy()) is False
+
+    def test_near_duplicate_is_same_scene(self) -> None:
+        detector = SceneChangeDetector(threshold=0.1)
+        frame = make_frame(seed=2)
+        detector.is_new_scene(frame)
+        assert detector.is_new_scene(add_noise(frame, amplitude=5, seed=99)) is False
+
+    def test_distinct_frame_is_new_scene(self) -> None:
+        detector = SceneChangeDetector(threshold=0.1)
+        detector.is_new_scene(make_frame(seed=3))
+        assert detector.is_new_scene(make_frame(seed=4)) is True
+
+    def test_new_scene_updates_stored_hash(self) -> None:
+        detector = SceneChangeDetector(threshold=0.1)
+        first = make_frame(seed=5)
+        second = make_frame(seed=6)
+        detector.is_new_scene(first)
+        detector.is_new_scene(second)
+        assert detector.last_hash == dhash(second)
+
+    def test_same_scene_does_not_update_stored_hash(self) -> None:
+        detector = SceneChangeDetector(threshold=0.1)
+        frame = make_frame(seed=7)
+        detector.is_new_scene(frame)
+        committed = detector.last_hash
+        detector.is_new_scene(add_noise(frame, amplitude=5, seed=11))
+        assert detector.last_hash == committed
+
+    def test_reset_makes_next_frame_new_scene(self) -> None:
+        detector = SceneChangeDetector(threshold=0.1)
+        frame = make_frame(seed=8)
+        detector.is_new_scene(frame)
+        detector.reset()
+        assert detector.last_hash is None
+        assert detector.is_new_scene(frame.copy()) is True
+
+    def test_zero_threshold_treats_any_difference_as_new_scene(self) -> None:
+        detector = SceneChangeDetector(threshold=0.0)
+        frame = make_frame(seed=9)
+        detector.is_new_scene(frame)
+        # A single-bit difference exceeds threshold 0.0.
+        assert detector.is_new_scene(add_noise(frame, amplitude=40, seed=12)) is True
+
+    def test_threshold_one_treats_everything_as_same_scene(self) -> None:
+        detector = SceneChangeDetector(threshold=1.0)
+        detector.is_new_scene(make_frame(seed=10))
+        # Even a completely different frame cannot exceed the maximum normalized distance.
+        assert detector.is_new_scene(make_frame(seed=11)) is False
+
+    def test_threshold_property_exposed(self) -> None:
+        assert SceneChangeDetector(threshold=0.25).threshold == 0.25
+
+    @pytest.mark.parametrize("threshold", [-0.1, 1.1])
+    def test_invalid_threshold_raises(self, threshold: float) -> None:
+        with pytest.raises(ValueError):
+            SceneChangeDetector(threshold=threshold)
+
+    @pytest.mark.parametrize("hash_size", [0, -1])
+    def test_invalid_hash_size_raises(self, hash_size: int) -> None:
+        with pytest.raises(ValueError):
+            SceneChangeDetector(hash_size=hash_size)


### PR DESCRIPTION
# Pull Request

## Description
This PR aims to add scene-aware frame skipping to the existing `FrameSkipPolicy` for the `Processor`. This is ensured using dHash, a perceptual hashing technique that is easy to compute and robust to compression noise and minor camera motion. Given a threshold, the normalized Hamming distance between the current and last-committed frame hashes determines whether a scene change has occurred and decides if the frame is to be processed.
## Type of Change

- [x] ✨ `feat` - New feature
- [ ] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## Breaking Changes

<!-- Describe if this breaks existing functionality -->

---
