### PR TITLE
fix: multi-category visual reference batch bug

### DIFF
--- a/application/backend/app/runtime/services/reference_batch.py
+++ b/application/backend/app/runtime/services/reference_batch.py
@@ -59,7 +59,8 @@ class ReferenceBatchService:
         models_metadata = self._supported_model_repo.get_by_model_type(model_type)
         supported_prompt_types = set(models_metadata.supported_prompt_types) if models_metadata else set()
         needs_bboxes = SupportedPromptType.VISUAL_BOUNDING_BOX in supported_prompt_types
-        use_label_names = needs_bboxes and get_settings().sam3_hybrid_mode
+        sam3_without_hybrid_mode = model_type == ModelType.SAM3 and not get_settings().sam3_hybrid_mode
+        use_label_names = not sam3_without_hybrid_mode
         return self._build_visual_batch(
             project_id=config.project_id, output_bboxes=needs_bboxes, use_label_names=use_label_names
         )
@@ -115,8 +116,10 @@ class ReferenceBatchService:
         Args:
             project_id: Project to build the batch for.
             output_bboxes: Produce bboxes instead of masks.
-            use_label_names: Pass real label names to samples; when False, ``"visual"``
-                placeholder is used instead.
+            use_label_names: Pass real label names to samples; when ``False``, the
+                ``"visual"`` sentinel is used instead so that SAM3 canvas helpers
+                recognise it as "no real category name" and do not forward it to
+                the text encoder.
 
         Returns:
             (Batch, category_id → label_id mapping) or None if no valid samples.
@@ -261,7 +264,7 @@ class ReferenceBatchService:
                 continue
 
             category_id = label_to_category_id[label_id]
-            category_name = label_id_to_name.get(label_id, str(label_id)) if label_id_to_name else "object"
+            category_name = label_id_to_name.get(label_id, str(label_id)) if label_id_to_name else "visual"
 
             if output_bboxes:
                 for polygon in polygons:

--- a/application/backend/tests/unit/runtime/services/test_reference_batch.py
+++ b/application/backend/tests/unit/runtime/services/test_reference_batch.py
@@ -660,13 +660,11 @@ class TestReferenceBatchServiceBuild:
         label_to_cat = {lid: idx for idx, lid in enumerate(sorted_ids)}
 
         fake_labels = [SimpleNamespace(id=lid, name=name) for lid, name in zip(label_ids, label_names)]
-        fake_settings = SimpleNamespace(sam3_hybrid_mode=False)
 
         with (
             patch("runtime.services.reference_batch.PromptRepository") as prompt_repo_cls,
             patch("runtime.services.reference_batch.LabelService") as label_svc_cls,
             patch("runtime.services.reference_batch.cv2.cvtColor", return_value=frame_bgr),
-            patch("runtime.services.reference_batch.get_settings", return_value=fake_settings),
         ):
             prompt_repo_cls.return_value.list_by_project_and_type.return_value = [prompt_db]
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(

--- a/application/backend/tests/unit/runtime/services/test_reference_batch.py
+++ b/application/backend/tests/unit/runtime/services/test_reference_batch.py
@@ -217,7 +217,7 @@ class TestVisualPromptToSample:
         assert result.category_labels == ["car"]
 
     def test_use_label_names_false_omits_categories(self, sample_frame: np.ndarray) -> None:
-        """When label_id_to_name is None, categories default to ["object"]."""
+        """When label_id_to_name is None, categories fall back to the "visual" sentinel."""
         label_id = uuid.uuid4()
         prompt_db, _ = _make_single_polygon_prompt(label_id)
         label_info = _make_label_info({label_id: None})
@@ -229,10 +229,10 @@ class TestVisualPromptToSample:
             output_bboxes=True,
         )
 
-        assert result.category_labels == ["object"]
+        assert result.category_labels == ["visual"]
 
     def test_use_label_names_false_with_multiple_labels_omits_categories(self, sample_frame: np.ndarray) -> None:
-        """Categories default to ["object"] when label_id_to_name is None, even with multiple labels."""
+        """Categories fall back to "visual" sentinel when label_id_to_name is None, even with multiple labels."""
         label_id_1 = uuid.uuid4()
         label_id_2 = uuid.uuid4()
         prompt_id = uuid.uuid4()
@@ -269,7 +269,7 @@ class TestVisualPromptToSample:
             output_bboxes=True,
         )
 
-        assert result.category_labels == ["object", "object"]
+        assert result.category_labels == ["visual", "visual"]
 
 
 def _make_single_polygon_prompt(
@@ -568,8 +568,8 @@ class TestReferenceBatchServiceBuild:
         assert call_kwargs["label_info"].label_id_to_name == {label_id: "car"}
         assert call_kwargs["output_bboxes"] is True
 
-    def test_build_matcher_does_not_use_label_names(self, service, frame_repository):
-        """Non-bbox models (Matcher) omit category names since use_label_names = needs_bboxes AND hybrid."""
+    def test_build_matcher_uses_label_names(self, service, frame_repository):
+        """Non-bbox models (Matcher) always use real label names."""
         cfg = PipelineConfig(project_id=uuid.uuid4(), processor=MatcherConfig(), prompt_mode=PromptType.VISUAL)
 
         fake_sample = MagicMock(name="Sample")
@@ -613,10 +613,71 @@ class TestReferenceBatchServiceBuild:
             label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
                 label_to_category_id={label_id: 0}, category_id_to_label_id={0: str(label_id)}
             )
-            label_svc_cls.return_value.get_labels_by_ids.return_value = []
+            label_svc_cls.return_value.get_labels_by_ids.return_value = [
+                SimpleNamespace(id=label_id, name="clementine")
+            ]
 
             service.build(cfg)
 
         call_kwargs = mock_to_sample.call_args.kwargs
         assert call_kwargs["output_bboxes"] is False
-        assert call_kwargs["label_info"].label_id_to_name is None
+        assert call_kwargs["label_info"].label_id_to_name == {label_id: "clementine"}
+
+    def test_matcher_multi_category_no_object_collision(self, service, frame_repository):
+        from instantlearn.models.torch_adapter import CategoryRegistry
+
+        cfg = PipelineConfig(project_id=uuid.uuid4(), processor=MatcherConfig(), prompt_mode=PromptType.VISUAL)
+
+        label_ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
+        label_names = ["clementine", "potato", "kiwi"]
+
+        frame_bgr = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+        frame_repository.read_frame.return_value = frame_bgr
+
+        prompt_id = uuid.uuid4()
+        # Single prompt with one annotation per label (one polygon each)
+        annotations = [
+            SimpleNamespace(
+                id=uuid.uuid4(),
+                config=PolygonAnnotation(
+                    points=[Point(x=5, y=5), Point(x=20, y=5), Point(x=20, y=20), Point(x=5, y=20)]
+                ).model_dump(),
+                label_id=lid,
+                prompt_id=prompt_id,
+            )
+            for lid in label_ids
+        ]
+        prompt_db = SimpleNamespace(
+            id=prompt_id,
+            type=PromptType.VISUAL,
+            text=None,
+            frame_id=uuid.uuid4(),
+            project_id=cfg.project_id,
+            annotations=annotations,
+        )
+
+        sorted_ids = sorted(label_ids, key=str)
+        label_to_cat = {lid: idx for idx, lid in enumerate(sorted_ids)}
+
+        fake_labels = [SimpleNamespace(id=lid, name=name) for lid, name in zip(label_ids, label_names)]
+        fake_settings = SimpleNamespace(sam3_hybrid_mode=False)
+
+        with (
+            patch("runtime.services.reference_batch.PromptRepository") as prompt_repo_cls,
+            patch("runtime.services.reference_batch.LabelService") as label_svc_cls,
+            patch("runtime.services.reference_batch.cv2.cvtColor", return_value=frame_bgr),
+            patch("runtime.services.reference_batch.get_settings", return_value=fake_settings),
+        ):
+            prompt_repo_cls.return_value.list_by_project_and_type.return_value = [prompt_db]
+            label_svc_cls.return_value.build_category_mappings.return_value = SimpleNamespace(
+                label_to_category_id=label_to_cat,
+                category_id_to_label_id={v: str(k) for k, v in label_to_cat.items()},
+            )
+            label_svc_cls.return_value.get_labels_by_ids.return_value = fake_labels
+
+            result = service.build(cfg)
+
+        assert result is not None
+        batch, _ = result
+        registry = CategoryRegistry.from_samples(batch)
+        assert set(registry.name_to_id.keys()) == {"clementine", "potato", "kiwi"}


### PR DESCRIPTION
Fixes a backend reference-batch construction bug that caused `CategoryRegistry` collisions (and a resulting `ValueError`) when fitting non-SAM3 visual-prompt models with multiple reference categories, by ensuring real label names are propagated for those models.

**Changes:**
- Adjusted `ReferenceBatchService.build()` so non-SAM3 visual models always receive `label_id_to_name` mappings (real label names), avoiding duplicate placeholder category names across distinct ids.
- Switched the “no real label names” placeholder from `"object"` to the SAM3-specific `"visual"` sentinel.
- Updated/added unit tests.

## Type of Change

- [ ] ✨ `feat` - New feature
- [x] 🐞 `fix` - Bug fix
- [ ] 📚 `docs` - Documentation
- [ ] ♻️ `refactor` - Code refactoring
- [ ] 🧪 `test` - Tests
- [ ] 🔧 `chore` - Maintenance

## Related Issues
Closes #1123

